### PR TITLE
Fix -L in CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -55,7 +55,7 @@ target_include_directories(pktvisorcore
 if (APPLE)
 target_link_libraries(pktvisorcore
         PRIVATE
-        "-L ${LIBPCPP_LIBRARY_DIRS}"
+        "-L${LIBPCPP_LIBRARY_DIRS}"
         ${LIBPCPP_LIBRARIES}
         "-framework CoreFoundation"
         "-framework SystemConfiguration"


### PR DESCRIPTION
Fixes cmake error found when building on macosx using cmake 3.18

```
CMake Error at CMakeLists.txt:40 (add_library):
  Target "pktvisorcore" links to item "-L " which has leading or trailing
  whitespace.  This is now an error according to policy CMP0004.


CMake Error at CMakeLists.txt:40 (add_library):
  Target "pktvisorcore" links to item "-L " which has leading or trailing
  whitespace.  This is now an error according to policy CMP0004.


CMake Error at CMakeLists.txt:40 (add_library):
  Target "pktvisorcore" links to item "-L " which has leading or trailing
  whitespace.  This is now an error according to policy CMP0004.
```