### PR TITLE
feature/taps

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ integration_tests/external
 golang/pkg/client/version.go
 docs/internals/html
 appimage/*.AppImage
+/test-config*.yaml

--- a/RFCs/2021-04-16-75-taps.md
+++ b/RFCs/2021-04-16-75-taps.md
@@ -24,18 +24,18 @@ visor:
   taps:
     # a pcap tap which uses eth0 and is referenced by the identifier "anycast"
     anycast:
-      type: pcap
+      input_type: pcap
       config:
         iface: eth0
     # an sflow tap which listens on the given IP and port, referenced by the identifier "pop_switch"
     pop_switch:
-      type: sflow
+      input_type: sflow
       config:
         port: 6343
         bind: 192.168.1.1
     # a dnstap tap which gets its stream from the given socket, named "trex_tap"
     trex_tap:
-      type: dnstap
+      input_type: dnstap
       config:
         socket: /var/dns.sock
 ```

--- a/cmd/pktvisor-pcap/main.cpp
+++ b/cmd/pktvisor-pcap/main.cpp
@@ -164,7 +164,7 @@ int main(int argc, char *argv[])
         input_stream->info_json(j["info"]);
         logger->info("{}", j.dump(4));
 
-        input_manager->module_add(std::move(input_stream), false);
+        input_manager->module_add(std::move(input_stream));
         auto [input_stream_, stream_mgr_lock] = input_manager->module_get_locked("pcap");
         stream_mgr_lock.unlock();
         auto pcap_stream = dynamic_cast<input::pcap::PcapInputStream *>(input_stream_);
@@ -173,6 +173,7 @@ int main(int argc, char *argv[])
         {
             auto handler_module = std::make_unique<handler::net::NetStreamHandler>("net", pcap_stream, periods, sample_rate);
             handler_module->config_set("recorded_stream", true);
+            handler_module->start();
             handler_manager->module_add(std::move(handler_module));
             auto [handler, handler_mgr_lock] = handler_manager->module_get_locked("net");
             handler_mgr_lock.unlock();
@@ -182,6 +183,7 @@ int main(int argc, char *argv[])
         {
             auto handler_module = std::make_unique<handler::dns::DnsStreamHandler>("dns", pcap_stream, periods, sample_rate);
             handler_module->config_set("recorded_stream", true);
+            handler_module->start();
             handler_manager->module_add(std::move(handler_module));
             auto [handler, handler_mgr_lock] = handler_manager->module_get_locked("dns");
             handler_mgr_lock.unlock();

--- a/cmd/pktvisor-pcap/main.cpp
+++ b/cmd/pktvisor-pcap/main.cpp
@@ -9,12 +9,7 @@
 
 #include <docopt/docopt.h>
 
-#include "HandlerManager.h"
-#include "HandlerModulePlugin.h"
-#include "InputModulePlugin.h"
-#include "InputStreamManager.h"
-#include <Corrade/PluginManager/Manager.h>
-#include <Corrade/PluginManager/PluginMetadata.h>
+#include "CoreManagers.h"
 #include <spdlog/sinks/stdout_color_sinks.h>
 
 #include "handlers/static_plugins.h"
@@ -60,10 +55,6 @@ void signal_handler(int signal)
 
 using namespace visor;
 
-typedef Corrade::PluginManager::Manager<InputModulePlugin> InputPluginRegistry;
-typedef Corrade::PluginManager::Manager<HandlerModulePlugin> HandlerPluginRegistry;
-typedef Corrade::Containers::Pointer<InputModulePlugin> InputPluginPtr;
-typedef Corrade::Containers::Pointer<HandlerModulePlugin> HandlerPluginPtr;
 
 void initialize_geo(const docopt::value &city, const docopt::value &asn)
 {
@@ -84,48 +75,12 @@ int main(int argc, char *argv[])
         true,           // show help if requested
         VISOR_VERSION); // version string
 
-    auto logger = spdlog::stderr_color_mt("pktvisor");
+    auto logger = spdlog::stderr_color_mt("visor");
     if (args["-v"].asBool()) {
         logger->set_level(spdlog::level::debug);
     }
 
-    // inputs
-    InputPluginRegistry input_registry;
-    auto input_manager = std::make_unique<InputStreamManager>();
-    std::vector<InputPluginPtr> input_plugins;
-
-    // initialize input plugins
-    for (auto &s : input_registry.pluginList()) {
-        InputPluginPtr mod = input_registry.instantiate(s);
-        logger->info("Load input plugin: {} {}", mod->name(), mod->pluginInterface());
-        mod->init_module(input_manager.get());
-        input_plugins.emplace_back(std::move(mod));
-    }
-
-    // handlers
-    HandlerPluginRegistry handler_registry;
-    auto handler_manager = std::make_unique<HandlerManager>();
-    std::vector<HandlerPluginPtr> handler_plugins;
-
-    // initialize handler plugins
-    for (auto &s : handler_registry.pluginList()) {
-        HandlerPluginPtr mod = handler_registry.instantiate(s);
-        logger->info("Load handler plugin: {} {}", mod->name(), mod->pluginInterface());
-        mod->init_module(input_manager.get(), handler_manager.get());
-        handler_plugins.emplace_back(std::move(mod));
-    }
-
-    shutdown_handler = [&]([[maybe_unused]] int signal) {
-        // gracefully close all inputs and handlers
-        auto [input_modules, im_lock] = input_manager->module_get_all_locked();
-        for (auto &[name, mod] : input_modules) {
-            mod->stop();
-        }
-        auto [handler_modules, hm_lock] = handler_manager->module_get_all_locked();
-        for (auto &[name, mod] : handler_modules) {
-            mod->stop();
-        }
-    };
+    CoreManagers mgrs(nullptr);
 
     std::signal(SIGINT, signal_handler);
     std::signal(SIGTERM, signal_handler);
@@ -164,8 +119,8 @@ int main(int argc, char *argv[])
         input_stream->info_json(j["info"]);
         logger->info("{}", j.dump(4));
 
-        input_manager->module_add(std::move(input_stream));
-        auto [input_stream_, stream_mgr_lock] = input_manager->module_get_locked("pcap");
+        mgrs.input_manager()->module_add(std::move(input_stream));
+        auto [input_stream_, stream_mgr_lock] = mgrs.input_manager()->module_get_locked("pcap");
         stream_mgr_lock.unlock();
         auto pcap_stream = dynamic_cast<input::pcap::PcapInputStream *>(input_stream_);
 
@@ -174,8 +129,8 @@ int main(int argc, char *argv[])
             auto handler_module = std::make_unique<handler::net::NetStreamHandler>("net", pcap_stream, periods, sample_rate);
             handler_module->config_set("recorded_stream", true);
             handler_module->start();
-            handler_manager->module_add(std::move(handler_module));
-            auto [handler, handler_mgr_lock] = handler_manager->module_get_locked("net");
+            mgrs.handler_manager()->module_add(std::move(handler_module));
+            auto [handler, handler_mgr_lock] = mgrs.handler_manager()->module_get_locked("net");
             handler_mgr_lock.unlock();
             net_handler = dynamic_cast<handler::net::NetStreamHandler *>(handler);
         }
@@ -184,8 +139,8 @@ int main(int argc, char *argv[])
             auto handler_module = std::make_unique<handler::dns::DnsStreamHandler>("dns", pcap_stream, periods, sample_rate);
             handler_module->config_set("recorded_stream", true);
             handler_module->start();
-            handler_manager->module_add(std::move(handler_module));
-            auto [handler, handler_mgr_lock] = handler_manager->module_get_locked("dns");
+            mgrs.handler_manager()->module_add(std::move(handler_module));
+            auto [handler, handler_mgr_lock] = mgrs.handler_manager()->module_get_locked("dns");
             handler_mgr_lock.unlock();
             dns_handler = dynamic_cast<handler::dns::DnsStreamHandler *>(handler);
         }

--- a/cmd/pktvisord/main.cpp
+++ b/cmd/pktvisord/main.cpp
@@ -199,7 +199,7 @@ int main(int argc, char *argv[])
 
     // local config file
     if (args["--config"]) {
-        logger->info("using config file: {}", args["--config"].asString());
+        logger->info("loading config file: {}", args["--config"].asString());
         YAML::Node config_file;
         // look for local options
         try {

--- a/cmd/pktvisord/main.cpp
+++ b/cmd/pktvisord/main.cpp
@@ -300,6 +300,7 @@ int main(int argc, char *argv[])
             auto input_manager = svr.input_manager();
             auto handler_manager = svr.handler_manager();
 
+            input_stream->start();
             input_manager->module_add(std::move(input_stream));
             auto [input_stream_, stream_mgr_lock] = input_manager->module_get_locked("pcap");
             stream_mgr_lock.unlock();
@@ -307,10 +308,12 @@ int main(int argc, char *argv[])
 
             {
                 auto handler_module = std::make_unique<handler::net::NetStreamHandler>("net", pcap_stream, periods, sample_rate);
+                handler_module->start();
                 handler_manager->module_add(std::move(handler_module));
             }
             {
                 auto handler_module = std::make_unique<handler::dns::DnsStreamHandler>("dns", pcap_stream, periods, sample_rate);
+                handler_module->start();
                 handler_manager->module_add(std::move(handler_module));
             }
 

--- a/cmd/pktvisord/main.cpp
+++ b/cmd/pktvisord/main.cpp
@@ -168,15 +168,15 @@ int main(int argc, char *argv[])
     std::shared_ptr<spdlog::logger> logger;
     if (args["--log-file"]) {
         try {
-            logger = spdlog::basic_logger_mt("pktvisor", args["--log-file"].asString());
+            logger = spdlog::basic_logger_mt("visor", args["--log-file"].asString());
         } catch (const spdlog::spdlog_ex &ex) {
             std::cerr << "Log init failed: " << ex.what() << std::endl;
             exit(EXIT_FAILURE);
         }
     } else if (args["--syslog"].asBool()) {
-        logger = spdlog::syslog_logger_mt("pktvisor", "pktvisord", LOG_PID);
+        logger = spdlog::syslog_logger_mt("visor", "pktvisord", LOG_PID);
     } else {
-        logger = spdlog::stdout_color_mt("pktvisor");
+        logger = spdlog::stdout_color_mt("visor");
     }
     if (args["-v"].asBool()) {
         logger->set_level(spdlog::level::debug);
@@ -220,8 +220,8 @@ int main(int argc, char *argv[])
                 }
             }
 
-            // then pass to CoreServer
-            svr.configure_from_file(args["--config"].asString());
+            // then pass to CoreManagers
+            svr.mgrs()->configure_from_file(args["--config"].asString());
 
         } catch (std::runtime_error &e) {
             logger->error("configuration error: {}", e.what());
@@ -297,8 +297,8 @@ int main(int argc, char *argv[])
             input_stream->config_set("bpf", bpf);
             input_stream->config_set("host_spec", host_spec);
 
-            auto input_manager = svr.input_manager();
-            auto handler_manager = svr.handler_manager();
+            auto input_manager = svr.mgrs()->input_manager();
+            auto handler_manager = svr.mgrs()->handler_manager();
 
             input_stream->start();
             input_manager->module_add(std::move(input_stream));

--- a/cmd/pktvisord/main.cpp
+++ b/cmd/pktvisord/main.cpp
@@ -189,7 +189,7 @@ int main(int argc, char *argv[])
             prom_config.instance = args["--prom-instance"].asString();
         }
     }
-    CoreServer svr(!args["--admin-api"].asBool(), logger, prom_config);
+    CoreServer svr(!args["--admin-api"].asBool(), prom_config);
     svr.set_http_logger([&logger](const auto &req, const auto &res) {
         logger->info("REQUEST: {} {} {}", req.method, req.path, res.status);
         if (res.status == 500) {

--- a/conanfile.txt
+++ b/conanfile.txt
@@ -7,6 +7,7 @@ cpp-httplib/0.8.0
 corrade/2020.06
 pcapplusplus/ns1-dev
 json-schema-validator/2.1.0
+yaml-cpp/0.6.3
 
 [build_requires]
 benchmark/1.5.2

--- a/conanfile.txt
+++ b/conanfile.txt
@@ -8,6 +8,7 @@ corrade/2020.06
 pcapplusplus/ns1-dev
 json-schema-validator/2.1.0
 yaml-cpp/0.6.3
+fmt/7.1.3
 
 [build_requires]
 benchmark/1.5.2

--- a/src/AbstractModule.h
+++ b/src/AbstractModule.h
@@ -22,7 +22,6 @@ class AbstractModule : public Configurable
 {
 
 protected:
-    std::atomic_bool _running = false;
 
     /**
      * the module instance identifier: unique name associated with this instance
@@ -32,7 +31,6 @@ protected:
     void _common_info_json(json &j) const
     {
         j["module"]["name"] = _name;
-        j["module"]["running"] = _running.load();
         config_json(j["module"]["config"]);
     }
 
@@ -40,15 +38,12 @@ public:
     AbstractModule(const std::string &name)
         : _name(name)
     {
-        if (!std::regex_match(name, std::regex("[a-zA-Z_][a-zA-Z0-9_]*"))) {
+        if (!std::regex_match(name, std::regex("[a-zA-Z_][a-zA-Z0-9_-]*"))) {
             throw std::runtime_error("invalid module name: " + name);
         }
     }
 
     virtual ~AbstractModule(){};
-
-    virtual void start() = 0;
-    virtual void stop() = 0;
 
     virtual void info_json(json &j) const = 0;
 
@@ -56,6 +51,31 @@ public:
     {
         return _name;
     }
+};
+
+class AbstractRunnableModule : public AbstractModule
+{
+
+protected:
+    std::atomic_bool _running = false;
+
+    void _common_info_json(json &j) const
+    {
+        j["module"]["name"] = _name;
+        j["module"]["running"] = _running.load();
+        config_json(j["module"]["config"]);
+    }
+
+public:
+    AbstractRunnableModule(const std::string &name)
+        : AbstractModule(name)
+    {
+    }
+
+    virtual ~AbstractRunnableModule(){};
+
+    virtual void start() = 0;
+    virtual void stop() = 0;
 
     /**
      * the module schema key: the same for all instances of this module

--- a/src/AbstractModule.h
+++ b/src/AbstractModule.h
@@ -4,9 +4,11 @@
 
 #pragma once
 
+#include "Configurable.h"
 #include <atomic>
 #include <exception>
 #include <nlohmann/json.hpp>
+#include <regex>
 #include <shared_mutex>
 #include <string>
 #include <unordered_map>
@@ -16,20 +18,8 @@ namespace visor {
 
 using json = nlohmann::json;
 
-class ConfigException : public std::runtime_error
+class AbstractModule : public Configurable
 {
-public:
-    explicit ConfigException(const std::string &msg)
-        : std::runtime_error(msg)
-    {
-    }
-};
-
-class AbstractModule
-{
-private:
-    std::unordered_map<std::string, std::variant<std::string, uint64_t, bool>> _config;
-    mutable std::shared_mutex _config_mutex;
 
 protected:
     std::atomic_bool _running = false;
@@ -50,6 +40,9 @@ public:
     AbstractModule(const std::string &name)
         : _name(name)
     {
+        if (!std::regex_match(name, std::regex("[a-zA-Z_][a-zA-Z0-9_]*"))) {
+            throw std::runtime_error("invalid module name: " + name);
+        }
     }
 
     virtual ~AbstractModule(){};
@@ -73,51 +66,6 @@ public:
     bool running() const
     {
         return _running;
-    }
-
-    template <class T>
-    auto config_get(const std::string &key)
-    {
-        std::shared_lock lock(_config_mutex);
-        if (_config.count(key) == 0) {
-            throw ConfigException("missing key: " + key);
-        }
-        auto val = std::get_if<T>(&_config[key]);
-        if (!val) {
-            throw ConfigException("wrong type for key: " + key);
-        }
-        return *val;
-    }
-
-    template <class T>
-    void config_set(const std::string &key, const T &val)
-    {
-        std::unique_lock lock(_config_mutex);
-        _config[key] = val;
-    }
-
-    // specialize to ensure a string literal is interpreted as a std::string
-    void config_set(const std::string &key, const char *val)
-    {
-        std::unique_lock lock(_config_mutex);
-        _config[key] = std::string(val);
-    }
-
-    bool config_exists(const std::string &name) const
-    {
-        std::shared_lock lock(_config_mutex);
-        return _config.count(name) == 1;
-    }
-
-    void config_json(json &j) const
-    {
-        std::shared_lock lock(_config_mutex);
-        for (const auto &[key, value] : _config) {
-            std::visit([&j, key = key](auto &&arg) {
-                j[key] = arg;
-            },
-                value);
-        }
     }
 };
 

--- a/src/AbstractPlugin.h
+++ b/src/AbstractPlugin.h
@@ -45,7 +45,6 @@ public:
     {
     }
 
-    virtual std::string name() const = 0;
 };
 
 }

--- a/src/AbstractPlugin.h
+++ b/src/AbstractPlugin.h
@@ -32,7 +32,7 @@ public:
 protected:
     void _check_schema(json obj, SchemaMap &required);
     void _check_schema(json obj, SchemaMap &required, SchemaMap &optional);
-    virtual void _setup_routes(HttpServer &svr) = 0;
+    virtual void _setup_routes(HttpServer *svr) = 0;
 
 public:
     static std::vector<std::string> pluginSearchPaths()

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -11,7 +11,8 @@ add_library(visor-core
         HandlerModulePlugin.cpp
         GeoDB.cpp
         CoreServer.cpp
-        Metrics.cpp Metrics.h)
+        Metrics.cpp
+        Taps.cpp)
 add_library(Visor::Core ALIAS visor-core)
 
 target_include_directories(visor-core

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -30,6 +30,7 @@ target_link_libraries(visor-core
         ${CONAN_LIBS_CORRADE}
         ${CONAN_LIBS_SPDLOG}
         ${CONAN_LIBS_FMT}
+        ${CONAN_LIBS_YAML-CPP}
         ${VISOR_STATIC_PLUGINS}
         )
 

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -11,6 +11,7 @@ add_library(visor-core
         HandlerModulePlugin.cpp
         GeoDB.cpp
         CoreServer.cpp
+        CoreManagers.cpp
         Metrics.cpp
         Taps.cpp)
 add_library(Visor::Core ALIAS visor-core)
@@ -48,13 +49,14 @@ add_executable(unit-tests-vizor-core
         tests/test_sketches.cpp
         tests/test_metrics.cpp
         tests/test_geoip.cpp
+        tests/test_taps.cpp
         )
 
 target_include_directories(unit-tests-vizor-core
         PRIVATE ${CMAKE_CURRENT_SOURCE_DIR}
         )
 
-target_link_libraries(unit-tests-vizor-core PRIVATE Visor::Core)
+target_link_libraries(unit-tests-vizor-core PRIVATE Visor::Core ${VISOR_STATIC_PLUGINS})
 
 add_test(NAME unit-tests-vizor-core
         WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}/src

--- a/src/Configurable.h
+++ b/src/Configurable.h
@@ -6,11 +6,14 @@
 
 #include <atomic>
 #include <exception>
+#include <fmt/core.h>
 #include <nlohmann/json.hpp>
+#include <regex>
 #include <shared_mutex>
 #include <string>
 #include <unordered_map>
 #include <variant>
+#include <yaml-cpp/yaml.h>
 
 namespace visor {
 
@@ -37,11 +40,11 @@ public:
     {
         std::shared_lock lock(_config_mutex);
         if (_config.count(key) == 0) {
-            throw ConfigException("missing key: " + key);
+            throw ConfigException(fmt::format("missing key: {}", key));
         }
         auto val = std::get_if<T>(&_config[key]);
         if (!val) {
-            throw ConfigException("wrong type for key: " + key);
+            throw ConfigException(fmt::format("wrong type for key: {}", key));
         }
         return *val;
     }
@@ -74,6 +77,30 @@ public:
                 j[key] = arg;
             },
                 value);
+        }
+    }
+
+    void config_set_yaml(const YAML::Node &config_yaml)
+    {
+        std::unique_lock lock(_config_mutex);
+        assert(config_yaml.IsMap());
+        for (YAML::const_iterator it = config_yaml.begin(); it != config_yaml.end(); ++it) {
+            auto key = it->first.as<std::string>();
+
+            if (!it->second.IsScalar()) {
+                throw ConfigException(fmt::format("invalid value for key: {}", key));
+            }
+
+            auto value = it->second.as<std::string>();
+
+            // the yaml library doesn't discriminate between scalar types, so we have to do that ourselves
+            if (std::regex_match(value, std::regex("[0-9]+"))) {
+                _config[key] = it->second.as<uint64_t>();
+            } else if (std::regex_match(value, std::regex("true|false", std::regex_constants::icase))) {
+                _config[key] = it->second.as<bool>();
+            } else {
+                _config[key] = value;
+            }
         }
     }
 };

--- a/src/CoreManagers.cpp
+++ b/src/CoreManagers.cpp
@@ -1,0 +1,100 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "CoreManagers.h"
+#include <spdlog/sinks/stdout_color_sinks.h>
+#include <spdlog/spdlog.h>
+
+namespace visor {
+
+CoreManagers::CoreManagers(HttpServer *svr)
+    : _svr(svr)
+{
+
+    _logger = spdlog::get("visor");
+    if (!_logger) {
+        _logger = spdlog::stderr_color_mt("visor");
+    }
+
+    if (!svr) {
+        _logger->warn("initializing modules with no HttpServer");
+    }
+
+    // inputs
+    _input_manager = std::make_unique<InputStreamManager>();
+
+    // initialize input plugins
+    {
+        auto alias_list = _input_registry.aliasList();
+        auto plugin_list = _input_registry.pluginList();
+        std::vector<std::string> by_alias;
+        std::set_difference(alias_list.begin(), alias_list.end(),
+            plugin_list.begin(), plugin_list.end(), std::inserter(by_alias, by_alias.begin()));
+        for (auto &s : by_alias) {
+            InputPluginPtr mod = _input_registry.instantiate(s);
+            _logger->info("Load input stream plugin: {} {}", s, mod->pluginInterface());
+            mod->init_module(_input_manager.get(), _svr);
+            _input_plugins.emplace_back(std::move(mod));
+        }
+    }
+
+    // handlers
+    _handler_manager = std::make_unique<HandlerManager>();
+
+    // initialize handler plugins
+    {
+        auto alias_list = _handler_registry.aliasList();
+        auto plugin_list = _handler_registry.pluginList();
+        std::vector<std::string> by_alias;
+        std::set_difference(alias_list.begin(), alias_list.end(),
+            plugin_list.begin(), plugin_list.end(), std::inserter(by_alias, by_alias.begin()));
+        for (auto &s : by_alias) {
+            HandlerPluginPtr mod = _handler_registry.instantiate(s);
+            _logger->info("Load stream handler plugin: {} {}", s, mod->pluginInterface());
+            mod->init_module(_input_manager.get(), _handler_manager.get(), _svr);
+            _handler_plugins.emplace_back(std::move(mod));
+        }
+    }
+
+    // taps
+    _tap_manager = std::make_unique<TapManager>(&_input_registry);
+}
+
+visor::CoreManagers::~CoreManagers()
+{
+    // gracefully close all inputs and handlers
+    auto [input_modules, im_lock] = _input_manager->module_get_all_locked();
+    for (auto &[name, mod] : input_modules) {
+        if (mod->running()) {
+            _logger->info("Stopping input instance: {}", mod->name());
+            mod->stop();
+        }
+    }
+    auto [handler_modules, hm_lock] = _handler_manager->module_get_all_locked();
+    for (auto &[name, mod] : handler_modules) {
+        if (mod->running()) {
+            _logger->info("Stopping handler instance: {}", mod->name());
+            mod->stop();
+        }
+    }
+}
+
+void visor::CoreManagers::configure_from_file(const std::string &filename)
+{
+    YAML::Node config_file = YAML::LoadFile(filename);
+
+    if (!config_file.IsMap() || !config_file["visor"]) {
+        throw ConfigException("invalid schema");
+    }
+    if (!config_file["version"] || !config_file["version"].IsScalar() || config_file["version"].as<std::string>() != "1.0") {
+        throw ConfigException("missing or unsupported version");
+    }
+
+    // taps
+    if (config_file["visor"]["taps"] && config_file["visor"]["taps"].IsMap()) {
+        _tap_manager->load(config_file["visor"]["taps"], true);
+    }
+}
+
+}

--- a/src/CoreManagers.h
+++ b/src/CoreManagers.h
@@ -1,0 +1,73 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#pragma once
+
+#include "HandlerModulePlugin.h"
+#include "InputModulePlugin.h"
+#include "Taps.h"
+#include <vector>
+
+namespace visor {
+
+class CoreManagers
+{
+
+    // these hold plugin instances: these are the types of modules available for instantiation
+    InputPluginRegistry _input_registry;
+    std::vector<InputPluginPtr> _input_plugins;
+
+    HandlerPluginRegistry _handler_registry;
+    std::vector<HandlerPluginPtr> _handler_plugins;
+
+    // these hold instances of active modules
+    std::unique_ptr<InputStreamManager> _input_manager;
+    std::unique_ptr<HandlerManager> _handler_manager;
+
+    std::unique_ptr<TapManager> _tap_manager;
+
+    std::shared_ptr<spdlog::logger> _logger;
+    HttpServer *_svr;
+
+public:
+    CoreManagers(HttpServer *svr);
+    ~CoreManagers();
+
+    void configure_from_file(const std::string &filename);
+
+    [[nodiscard]] const InputStreamManager *input_manager() const
+    {
+        return _input_manager.get();
+    }
+    [[nodiscard]] const HandlerManager *handler_manager() const
+    {
+        return _handler_manager.get();
+    }
+    [[nodiscard]] const TapManager *tap_manager() const
+    {
+        return _tap_manager.get();
+    }
+    [[nodiscard]] const InputPluginRegistry *input_plugin_registry() const
+    {
+        return &_input_registry;
+    }
+
+    [[nodiscard]] InputStreamManager *input_manager()
+    {
+        return _input_manager.get();
+    }
+
+    [[nodiscard]] HandlerManager *handler_manager()
+    {
+        return _handler_manager.get();
+    }
+
+    [[nodiscard]] TapManager *tap_manager()
+    {
+        return _tap_manager.get();
+    }
+
+};
+
+}

--- a/src/CoreServer.cpp
+++ b/src/CoreServer.cpp
@@ -217,6 +217,6 @@ void visor::CoreServer::configure_from_file(const std::string &filename)
 
     // taps
     if (config_file["visor"]["taps"] && config_file["visor"]["taps"].IsMap()) {
-        _tap_manager->load(config_file["visor"]["taps"]);
+        _tap_manager->load(config_file["visor"]["taps"], true);
     }
 }

--- a/src/CoreServer.cpp
+++ b/src/CoreServer.cpp
@@ -196,4 +196,7 @@ void visor::CoreServer::configure_from_file(const std::string &filename)
     }
 
     // taps
+    if (config_file["visor"]["taps"] && config_file["visor"]["taps"].IsMap()) {
+        auto taps = config_file["visor"]["taps"];
+    }
 }

--- a/src/CoreServer.cpp
+++ b/src/CoreServer.cpp
@@ -37,6 +37,9 @@ visor::CoreServer::CoreServer(bool read_only, std::shared_ptr<spdlog::logger> lo
         _handler_plugins.emplace_back(std::move(mod));
     }
 
+    // taps
+    _tap_manager = std::make_unique<TapManager>();
+
     _setup_routes(prom_config);
     if (!prom_config.instance.empty()) {
         Metric::add_base_label("instance", prom_config.instance);

--- a/src/CoreServer.cpp
+++ b/src/CoreServer.cpp
@@ -186,5 +186,14 @@ void visor::CoreServer::_setup_routes(const PrometheusConfig &prom_config)
 }
 void visor::CoreServer::configure_from_file(const std::string &filename)
 {
-    YAML::Node config = YAML::LoadFile(filename);
+    YAML::Node config_file = YAML::LoadFile(filename);
+
+    if (!config_file.IsMap() || !config_file["visor"]) {
+        throw std::runtime_error("invalid schema");
+    }
+    if (!config_file["version"] || !config_file["version"].IsScalar() || config_file["version"].as<std::string>() != "1.0") {
+        throw std::runtime_error("missing or unsupported version");
+    }
+
+    // taps
 }

--- a/src/CoreServer.cpp
+++ b/src/CoreServer.cpp
@@ -184,3 +184,7 @@ void visor::CoreServer::_setup_routes(const PrometheusConfig &prom_config)
         });
     }
 }
+void visor::CoreServer::configure_from_file(const std::string &filename)
+{
+    YAML::Node config = YAML::LoadFile(filename);
+}

--- a/src/CoreServer.h
+++ b/src/CoreServer.h
@@ -13,6 +13,7 @@
 #include <Corrade/PluginManager/Manager.h>
 #include <Corrade/PluginManager/PluginMetadata.h>
 #include <atomic>
+#include <map>
 #include <spdlog/spdlog.h>
 #include <yaml-cpp/yaml.h>
 
@@ -25,13 +26,12 @@ struct PrometheusConfig {
 
 class CoreServer
 {
-public:
-private:
     typedef Corrade::PluginManager::Manager<InputModulePlugin> InputPluginRegistry;
     typedef Corrade::PluginManager::Manager<HandlerModulePlugin> HandlerPluginRegistry;
     typedef Corrade::Containers::Pointer<InputModulePlugin> InputPluginPtr;
     typedef Corrade::Containers::Pointer<HandlerModulePlugin> HandlerPluginPtr;
 
+    // these hold plugin instances: these are the types of modules available for instantiation
     InputPluginRegistry _input_registry;
     std::vector<InputPluginPtr> _input_plugins;
 
@@ -40,8 +40,10 @@ private:
 
     visor::HttpServer _svr;
 
+    // these hold instances of active modules
     std::unique_ptr<InputStreamManager> _input_manager;
     std::unique_ptr<HandlerManager> _handler_manager;
+
     std::unique_ptr<TapManager> _tap_manager;
 
     std::shared_ptr<spdlog::logger> _logger;
@@ -63,6 +65,19 @@ public:
         _svr.set_logger(logger);
     }
 
+    const InputStreamManager *input_manager() const
+    {
+        return _input_manager.get();
+    }
+    const HandlerManager *handler_manager() const
+    {
+        return _handler_manager.get();
+    }
+    const TapManager *tap_manager() const
+    {
+        return _tap_manager.get();
+    }
+
     InputStreamManager *input_manager()
     {
         return _input_manager.get();
@@ -70,6 +85,10 @@ public:
     HandlerManager *handler_manager()
     {
         return _handler_manager.get();
+    }
+    TapManager *tap_manager()
+    {
+        return _tap_manager.get();
     }
 };
 

--- a/src/CoreServer.h
+++ b/src/CoreServer.h
@@ -4,16 +4,10 @@
 
 #pragma once
 
-#include "HandlerManager.h"
-#include "HandlerModulePlugin.h"
+#include "CoreManagers.h"
 #include "HttpServer.h"
-#include "InputModulePlugin.h"
-#include "InputStreamManager.h"
-#include "Taps.h"
-#include <atomic>
-#include <map>
+#include <chrono>
 #include <spdlog/spdlog.h>
-#include <yaml-cpp/yaml.h>
 
 namespace visor {
 
@@ -25,20 +19,8 @@ struct PrometheusConfig {
 class CoreServer
 {
 
-    // these hold plugin instances: these are the types of modules available for instantiation
-    InputPluginRegistry _input_registry;
-    std::vector<InputPluginPtr> _input_plugins;
-
-    HandlerPluginRegistry _handler_registry;
-    std::vector<HandlerPluginPtr> _handler_plugins;
-
-    visor::HttpServer _svr;
-
-    // these hold instances of active modules
-    std::unique_ptr<InputStreamManager> _input_manager;
-    std::unique_ptr<HandlerManager> _handler_manager;
-
-    std::unique_ptr<TapManager> _tap_manager;
+    HttpServer _svr;
+    CoreManagers _mgrs;
 
     std::shared_ptr<spdlog::logger> _logger;
     std::chrono::system_clock::time_point _start_time;
@@ -52,41 +34,19 @@ public:
     void start(const std::string &host, int port);
     void stop();
 
-    void configure_from_file(const std::string &filename);
+    const CoreManagers *mgrs() const
+    {
+        return &_mgrs;
+    }
+
+    CoreManagers *mgrs()
+    {
+        return &_mgrs;
+    }
 
     void set_http_logger(httplib::Logger logger)
     {
         _svr.set_logger(logger);
-    }
-
-    const InputStreamManager *input_manager() const
-    {
-        return _input_manager.get();
-    }
-    const HandlerManager *handler_manager() const
-    {
-        return _handler_manager.get();
-    }
-    const TapManager *tap_manager() const
-    {
-        return _tap_manager.get();
-    }
-    const InputPluginRegistry *input_plugin_registry() const
-    {
-        return &_input_registry;
-    }
-
-    InputStreamManager *input_manager()
-    {
-        return _input_manager.get();
-    }
-    HandlerManager *handler_manager()
-    {
-        return _handler_manager.get();
-    }
-    TapManager *tap_manager()
-    {
-        return _tap_manager.get();
     }
 };
 

--- a/src/CoreServer.h
+++ b/src/CoreServer.h
@@ -10,8 +10,6 @@
 #include "InputModulePlugin.h"
 #include "InputStreamManager.h"
 #include "Taps.h"
-#include <Corrade/PluginManager/Manager.h>
-#include <Corrade/PluginManager/PluginMetadata.h>
 #include <atomic>
 #include <map>
 #include <spdlog/spdlog.h>
@@ -26,10 +24,6 @@ struct PrometheusConfig {
 
 class CoreServer
 {
-    typedef Corrade::PluginManager::Manager<InputModulePlugin> InputPluginRegistry;
-    typedef Corrade::PluginManager::Manager<HandlerModulePlugin> HandlerPluginRegistry;
-    typedef Corrade::Containers::Pointer<InputModulePlugin> InputPluginPtr;
-    typedef Corrade::Containers::Pointer<HandlerModulePlugin> HandlerPluginPtr;
 
     // these hold plugin instances: these are the types of modules available for instantiation
     InputPluginRegistry _input_registry;
@@ -52,7 +46,7 @@ class CoreServer
     void _setup_routes(const PrometheusConfig &prom_config);
 
 public:
-    CoreServer(bool read_only, std::shared_ptr<spdlog::logger> logger, const PrometheusConfig &prom_config);
+    CoreServer(bool read_only, const PrometheusConfig &prom_config);
     ~CoreServer();
 
     void start(const std::string &host, int port);
@@ -76,6 +70,10 @@ public:
     const TapManager *tap_manager() const
     {
         return _tap_manager.get();
+    }
+    const InputPluginRegistry *input_plugin_registry() const
+    {
+        return &_input_registry;
     }
 
     InputStreamManager *input_manager()

--- a/src/CoreServer.h
+++ b/src/CoreServer.h
@@ -13,6 +13,7 @@
 #include <Corrade/PluginManager/PluginMetadata.h>
 #include <atomic>
 #include <spdlog/spdlog.h>
+#include <yaml-cpp/yaml.h>
 
 namespace visor {
 
@@ -52,6 +53,8 @@ public:
 
     void start(const std::string &host, int port);
     void stop();
+
+    void configure_from_file(const std::string &filename);
 
     void set_http_logger(httplib::Logger logger)
     {

--- a/src/CoreServer.h
+++ b/src/CoreServer.h
@@ -9,6 +9,7 @@
 #include "HttpServer.h"
 #include "InputModulePlugin.h"
 #include "InputStreamManager.h"
+#include "Taps.h"
 #include <Corrade/PluginManager/Manager.h>
 #include <Corrade/PluginManager/PluginMetadata.h>
 #include <atomic>
@@ -41,6 +42,7 @@ private:
 
     std::unique_ptr<InputStreamManager> _input_manager;
     std::unique_ptr<HandlerManager> _handler_manager;
+    std::unique_ptr<TapManager> _tap_manager;
 
     std::shared_ptr<spdlog::logger> _logger;
     std::chrono::system_clock::time_point _start_time;

--- a/src/HandlerModulePlugin.cpp
+++ b/src/HandlerModulePlugin.cpp
@@ -3,26 +3,19 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 #include "HandlerModulePlugin.h"
-#include <Corrade/Utility/Format.h>
-#include <Corrade/Utility/FormatStl.h>
 
 namespace visor {
 
 void HandlerModulePlugin::init_module(InputStreamManager *im,
-    HandlerManager *hm, HttpServer &svr)
+    HandlerManager *hm, HttpServer *svr)
 {
     assert(hm);
     assert(im);
     _input_manager = im;
     _handler_manager = hm;
-    _setup_routes(svr);
-}
-void HandlerModulePlugin::init_module(InputStreamManager *im, HandlerManager *hm)
-{
-    assert(hm);
-    assert(im);
-    _input_manager = im;
-    _handler_manager = hm;
+    if (svr) {
+        _setup_routes(svr);
+    }
 }
 
 }

--- a/src/HandlerModulePlugin.h
+++ b/src/HandlerModulePlugin.h
@@ -19,7 +19,7 @@ protected:
     visor::InputStreamManager *_input_manager;
     visor::HandlerManager *_handler_manager;
 
-    virtual void _setup_routes(HttpServer &svr) = 0;
+    virtual void _setup_routes(HttpServer *svr) = 0;
 
 public:
     static std::string pluginInterface()
@@ -39,10 +39,7 @@ public:
 
     void init_module(InputStreamManager *im,
         HandlerManager *hm,
-        HttpServer &svr);
-
-    void init_module(InputStreamManager *im,
-        HandlerManager *hm);
+        HttpServer *svr);
 };
 
 typedef Corrade::PluginManager::Manager<HandlerModulePlugin> HandlerPluginRegistry;

--- a/src/HandlerModulePlugin.h
+++ b/src/HandlerModulePlugin.h
@@ -22,7 +22,7 @@ protected:
 public:
     static std::string pluginInterface()
     {
-        return "dev.visor.module.handler/1.0";
+        return "visor.module.handler/1.0";
     }
 
     static std::vector<std::string> pluginSearchPaths()

--- a/src/HandlerModulePlugin.h
+++ b/src/HandlerModulePlugin.h
@@ -7,6 +7,8 @@
 #include "AbstractPlugin.h"
 #include "HandlerManager.h"
 #include "InputStreamManager.h"
+#include <Corrade/PluginManager/Manager.h>
+#include <Corrade/PluginManager/PluginMetadata.h>
 #include <string>
 
 namespace visor {
@@ -35,8 +37,6 @@ public:
     {
     }
 
-    virtual std::string name() const = 0;
-
     void init_module(InputStreamManager *im,
         HandlerManager *hm,
         HttpServer &svr);
@@ -45,5 +45,7 @@ public:
         HandlerManager *hm);
 };
 
-}
+typedef Corrade::PluginManager::Manager<HandlerModulePlugin> HandlerPluginRegistry;
+typedef Corrade::Containers::Pointer<HandlerModulePlugin> HandlerPluginPtr;
 
+}

--- a/src/HttpServer.h
+++ b/src/HttpServer.h
@@ -20,7 +20,7 @@ public:
 
     Server &Get(const char *pattern, Handler handler)
     {
-        spdlog::get("pktvisor")->info("Registering GET {}", pattern);
+        spdlog::get("visor")->info("Registering GET {}", pattern);
         return httplib::Server::Get(pattern, handler);
     }
     Server &Post(const char *pattern, Handler handler)
@@ -28,7 +28,7 @@ public:
         if (_read_only) {
             return *this;
         }
-        spdlog::get("pktvisor")->info("Registering POST {}", pattern);
+        spdlog::get("visor")->info("Registering POST {}", pattern);
         return httplib::Server::Post(pattern, handler);
     }
     Server &Put(const char *pattern, Handler handler)
@@ -36,7 +36,7 @@ public:
         if (_read_only) {
             return *this;
         }
-        spdlog::get("pktvisor")->info("Registering PUT {}", pattern);
+        spdlog::get("visor")->info("Registering PUT {}", pattern);
         return httplib::Server::Put(pattern, handler);
     }
     Server &Delete(const char *pattern, Handler handler)
@@ -44,7 +44,7 @@ public:
         if (_read_only) {
             return *this;
         }
-        spdlog::get("pktvisor")->info("Registering DELETE {}", pattern);
+        spdlog::get("visor")->info("Registering DELETE {}", pattern);
         return httplib::Server::Delete(pattern, handler);
     }
 };

--- a/src/InputModulePlugin.cpp
+++ b/src/InputModulePlugin.cpp
@@ -3,21 +3,16 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 #include "InputModulePlugin.h"
-#include <Corrade/Utility/Format.h>
-#include <Corrade/Utility/FormatStl.h>
 
 namespace visor {
 
-void InputModulePlugin::init_module(InputStreamManager *im, HttpServer &svr)
+void InputModulePlugin::init_module(InputStreamManager *im, HttpServer *svr)
 {
     assert(im);
     _input_manager = im;
-    _setup_routes(svr);
-}
-void InputModulePlugin::init_module(InputStreamManager *im)
-{
-    assert(im);
-    _input_manager = im;
+    if (svr) {
+        _setup_routes(svr);
+    }
 }
 
 }

--- a/src/InputModulePlugin.h
+++ b/src/InputModulePlugin.h
@@ -6,6 +6,8 @@
 
 #include "AbstractPlugin.h"
 #include "InputStreamManager.h"
+#include <Corrade/PluginManager/Manager.h>
+#include <Corrade/PluginManager/PluginMetadata.h>
 #include <string>
 
 namespace visor {
@@ -34,11 +36,11 @@ public:
     {
     }
 
-    virtual std::string name() const = 0;
-
     void init_module(InputStreamManager *im, HttpServer &svr);
     void init_module(InputStreamManager *im);
 };
 
-}
+typedef Corrade::PluginManager::Manager<InputModulePlugin> InputPluginRegistry;
+typedef Corrade::Containers::Pointer<InputModulePlugin> InputPluginPtr;
 
+}

--- a/src/InputModulePlugin.h
+++ b/src/InputModulePlugin.h
@@ -14,14 +14,14 @@ class InputModulePlugin : public AbstractPlugin
 {
 
 protected:
-    visor::InputStreamManager *_input_manager;
+    InputStreamManager *_input_manager;
 
     virtual void _setup_routes(HttpServer &svr) = 0;
 
 public:
     static std::string pluginInterface()
     {
-        return "dev.visor.module.input/1.0";
+        return "visor.module.input/1.0";
     }
 
     static std::vector<std::string> pluginSearchPaths()

--- a/src/InputModulePlugin.h
+++ b/src/InputModulePlugin.h
@@ -18,7 +18,7 @@ class InputModulePlugin : public AbstractPlugin
 protected:
     InputStreamManager *_input_manager;
 
-    virtual void _setup_routes(HttpServer &svr) = 0;
+    virtual void _setup_routes(HttpServer *svr) = 0;
 
 public:
     static std::string pluginInterface()
@@ -36,8 +36,7 @@ public:
     {
     }
 
-    void init_module(InputStreamManager *im, HttpServer &svr);
-    void init_module(InputStreamManager *im);
+    void init_module(InputStreamManager *im, HttpServer *svr);
 };
 
 typedef Corrade::PluginManager::Manager<InputModulePlugin> InputPluginRegistry;

--- a/src/InputStream.h
+++ b/src/InputStream.h
@@ -9,12 +9,12 @@
 
 namespace visor {
 
-class InputStream : public AbstractModule
+class InputStream : public AbstractRunnableModule
 {
 
 public:
     InputStream(const std::string &name)
-        : AbstractModule(name)
+        : AbstractRunnableModule(name)
     {
     }
 

--- a/src/Metrics.h
+++ b/src/Metrics.h
@@ -16,6 +16,7 @@
 #include <kll_sketch.hpp>
 #pragma GCC diagnostic pop
 #include <chrono>
+#include <regex>
 #include <shared_mutex>
 #include <vector>
 
@@ -40,12 +41,25 @@ protected:
     std::string _desc;
     std::string _schema_key;
 
+    void _check_names()
+    {
+        for (const auto &name : _name) {
+            if (!std::regex_match(name, std::regex("[a-zA-Z_][a-zA-Z0-9_]*"))) {
+                throw std::runtime_error("invalid metric name: " + name);
+            }
+        }
+        if (!std::regex_match(_schema_key, std::regex("[a-zA-Z_][a-zA-Z0-9_]*"))) {
+            throw std::runtime_error("invalid schema name: " + _schema_key);
+        }
+    }
+
 public:
     Metric(std::string schema_key, std::initializer_list<std::string> names, std::string desc)
         : _name(names)
         , _desc(std::move(desc))
         , _schema_key(schema_key)
     {
+        _check_names();
     }
 
     void set_info(std::string schema_key, std::initializer_list<std::string> names, const std::string &desc)
@@ -54,6 +68,7 @@ public:
         _name = names;
         _desc = desc;
         _schema_key = schema_key;
+        _check_names();
     }
 
     static void add_base_label(const std::string &label, const std::string &value)

--- a/src/StreamHandler.h
+++ b/src/StreamHandler.h
@@ -13,12 +13,12 @@ namespace visor {
 
 using json = nlohmann::json;
 
-class StreamHandler : public AbstractModule
+class StreamHandler : public AbstractRunnableModule
 {
 
 public:
     StreamHandler(const std::string &name)
-        : AbstractModule(name)
+        : AbstractRunnableModule(name)
     {
     }
 

--- a/src/Taps.cpp
+++ b/src/Taps.cpp
@@ -10,6 +10,7 @@
 void visor::TapManager::load(const YAML::Node &tap_yaml, bool strict)
 {
     assert(tap_yaml.IsMap());
+    assert(spdlog::get("visor"));
 
     auto input_plugins = _input_plugin_registry->aliasList();
 
@@ -18,7 +19,7 @@ void visor::TapManager::load(const YAML::Node &tap_yaml, bool strict)
             throw ConfigException("expecting tap identifier");
         }
         auto tap_name = it->first.as<std::string>();
-        spdlog::get("pktvisor")->info("loading Tap: {}", tap_name);
+        spdlog::get("visor")->info("loading Tap: {}", tap_name);
         if (!it->second.IsMap()) {
             throw ConfigException("expecting tap configuration map");
         }
@@ -30,7 +31,7 @@ void visor::TapManager::load(const YAML::Node &tap_yaml, bool strict)
             if (strict) {
                 throw ConfigException(fmt::format("Tap '{}' requires input stream type '{}' which is not available", tap_name, input_type));
             } else {
-                spdlog::get("pktvisor")->warn("Tap '{}' requires input stream type '{}' which is not available; skipping", tap_name, input_type);
+                spdlog::get("visor")->warn("Tap '{}' requires input stream type '{}' which is not available; skipping", tap_name, input_type);
                 continue;
             }
         }

--- a/src/Taps.cpp
+++ b/src/Taps.cpp
@@ -4,9 +4,10 @@
 
 #include "Taps.h"
 #include <algorithm>
+#include <fmt/core.h>
 #include <spdlog/spdlog.h>
 
-void visor::TapManager::load(const YAML::Node &tap_yaml)
+void visor::TapManager::load(const YAML::Node &tap_yaml, bool strict)
 {
     assert(tap_yaml.IsMap());
 
@@ -26,8 +27,12 @@ void visor::TapManager::load(const YAML::Node &tap_yaml)
         }
         auto tap_type = it->second["type"].as<std::string>();
         if (std::find(input_plugins.begin(), input_plugins.end(), tap_type) == input_plugins.end()) {
-            spdlog::get("pktvisor")->warn("Tap '{}' requires input stream type '{}' which is not available; skipping", tap_name, tap_type);
-            continue;
+            if (strict) {
+                throw ConfigException(fmt::format("Tap '{}' requires input stream type '{}' which is not available", tap_name, tap_type));
+            } else {
+                spdlog::get("pktvisor")->warn("Tap '{}' requires input stream type '{}' which is not available; skipping", tap_name, tap_type);
+                continue;
+            }
         }
     }
 }

--- a/src/Taps.cpp
+++ b/src/Taps.cpp
@@ -34,5 +34,16 @@ void visor::TapManager::load(const YAML::Node &tap_yaml, bool strict)
                 continue;
             }
         }
+
+        auto tap_module = std::make_unique<Tap>(tap_name);
+
+        if (it->second["config"]) {
+            if (!it->second["config"].IsMap()) {
+                throw ConfigException("tap configuration is not a map");
+            }
+            tap_module->config_set_yaml(it->second["config"]);
+        }
+
+        module_add(std::move(tap_module));
     }
 }

--- a/src/Taps.cpp
+++ b/src/Taps.cpp
@@ -3,11 +3,15 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 #include "Taps.h"
+#include <algorithm>
 #include <spdlog/spdlog.h>
 
 void visor::TapManager::load(const YAML::Node &tap_yaml)
 {
     assert(tap_yaml.IsMap());
+
+    auto input_plugins = _input_plugin_registry->aliasList();
+
     for (YAML::const_iterator it = tap_yaml.begin(); it != tap_yaml.end(); ++it) {
         if (!it->first.IsScalar()) {
             throw ConfigException("expecting tap identifier");
@@ -21,7 +25,7 @@ void visor::TapManager::load(const YAML::Node &tap_yaml)
             throw ConfigException("missing or invalid tap input stream 'type'");
         }
         auto tap_type = it->second["type"].as<std::string>();
-        if (!_input_manager->module_exists(tap_type)) {
+        if (std::find(input_plugins.begin(), input_plugins.end(), tap_type) == input_plugins.end()) {
             spdlog::get("pktvisor")->warn("Tap '{}' requires input stream type '{}' which is not available; skipping", tap_name, tap_type);
             continue;
         }

--- a/src/Taps.cpp
+++ b/src/Taps.cpp
@@ -22,20 +22,20 @@ void visor::TapManager::load(const YAML::Node &tap_yaml, bool strict)
         if (!it->second.IsMap()) {
             throw ConfigException("expecting tap configuration map");
         }
-        if (!it->second["type"] || !it->second["type"].IsScalar()) {
-            throw ConfigException("missing or invalid tap input stream 'type'");
+        if (!it->second["input_type"] || !it->second["input_type"].IsScalar()) {
+            throw ConfigException("missing or invalid tap type key 'input_type'");
         }
-        auto tap_type = it->second["type"].as<std::string>();
-        if (std::find(input_plugins.begin(), input_plugins.end(), tap_type) == input_plugins.end()) {
+        auto input_type = it->second["input_type"].as<std::string>();
+        if (std::find(input_plugins.begin(), input_plugins.end(), input_type) == input_plugins.end()) {
             if (strict) {
-                throw ConfigException(fmt::format("Tap '{}' requires input stream type '{}' which is not available", tap_name, tap_type));
+                throw ConfigException(fmt::format("Tap '{}' requires input stream type '{}' which is not available", tap_name, input_type));
             } else {
-                spdlog::get("pktvisor")->warn("Tap '{}' requires input stream type '{}' which is not available; skipping", tap_name, tap_type);
+                spdlog::get("pktvisor")->warn("Tap '{}' requires input stream type '{}' which is not available; skipping", tap_name, input_type);
                 continue;
             }
         }
 
-        auto tap_module = std::make_unique<Tap>(tap_name);
+        auto tap_module = std::make_unique<Tap>(tap_name, input_type);
 
         if (it->second["config"]) {
             if (!it->second["config"].IsMap()) {

--- a/src/Taps.cpp
+++ b/src/Taps.cpp
@@ -3,5 +3,27 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 #include "Taps.h"
+#include <spdlog/spdlog.h>
 
-
+void visor::TapManager::load(const YAML::Node &tap_yaml)
+{
+    assert(tap_yaml.IsMap());
+    for (YAML::const_iterator it = tap_yaml.begin(); it != tap_yaml.end(); ++it) {
+        if (!it->first.IsScalar()) {
+            throw ConfigException("expecting tap identifier");
+        }
+        auto tap_name = it->first.as<std::string>();
+        spdlog::get("pktvisor")->info("loading Tap: {}", tap_name);
+        if (!it->second.IsMap()) {
+            throw ConfigException("expecting tap configuration map");
+        }
+        if (!it->second["type"] || !it->second["type"].IsScalar()) {
+            throw ConfigException("missing or invalid tap input stream 'type'");
+        }
+        auto tap_type = it->second["type"].as<std::string>();
+        if (!_input_manager->module_exists(tap_type)) {
+            spdlog::get("pktvisor")->warn("Tap '{}' requires input stream type '{}' which is not available; skipping", tap_name, tap_type);
+            continue;
+        }
+    }
+}

--- a/src/Taps.cpp
+++ b/src/Taps.cpp
@@ -3,12 +3,5 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 #include "Taps.h"
-#include <regex>
 
-visor::Tap::Tap(const std::string &name)
-    : _name(name)
-{
-    if (!std::regex_match(name, std::regex("[a-zA-Z_][a-zA-Z0-9_]*"))) {
-        throw std::runtime_error("invalid tap name: " + name);
-    }
-}
+

--- a/src/Taps.cpp
+++ b/src/Taps.cpp
@@ -1,0 +1,14 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#include "Taps.h"
+#include <regex>
+
+visor::Tap::Tap(const std::string &name)
+    : _name(name)
+{
+    if (!std::regex_match(name, std::regex("[a-zA-Z_][a-zA-Z0-9_]*"))) {
+        throw std::runtime_error("invalid tap name: " + name);
+    }
+}

--- a/src/Taps.h
+++ b/src/Taps.h
@@ -15,14 +15,19 @@ namespace visor {
 class Tap : public AbstractModule
 {
 
+    std::string _input_type;
+
 public:
-    Tap(const std::string &name)
+    Tap(const std::string &name, const std::string &input_type)
         : AbstractModule(name)
+        , _input_type(input_type)
     {
     }
 
-    void info_json(json &j) const override {
-        AbstractModule::_common_info_json(j);
+    void info_json(json &j) const override
+    {
+        j["input_type"] = _input_type;
+        config_json(j["config"]);
     }
 };
 

--- a/src/Taps.h
+++ b/src/Taps.h
@@ -7,6 +7,8 @@
 #include "AbstractManager.h"
 #include "AbstractModule.h"
 #include "Configurable.h"
+#include "InputStreamManager.h"
+#include <yaml-cpp/yaml.h>
 
 namespace visor {
 
@@ -22,10 +24,20 @@ public:
 
 class TapManager : public AbstractManager<Tap>
 {
+
+    const InputStreamManager *_input_manager;
+
 public:
+    TapManager(const InputStreamManager *inputManager)
+        : _input_manager(inputManager)
+    {
+    }
+
     virtual ~TapManager()
     {
     }
+
+    void load(const YAML::Node &tap_yaml);
 };
 
 }

--- a/src/Taps.h
+++ b/src/Taps.h
@@ -4,24 +4,28 @@
 
 #pragma once
 
+#include "AbstractManager.h"
+#include "AbstractModule.h"
 #include "Configurable.h"
 
 namespace visor {
 
-class Tap : public Configurable
+class Tap : public AbstractModule
 {
-protected:
-    /**
-     * the tap identifier: unique name associated with this Tap
-     */
-    std::string _name;
 
 public:
-    Tap(const std::string &name);
+    Tap(const std::string &name)
+        : AbstractModule(name)
+    {
+    }
 };
 
-class TapManager
+class TapManager : public AbstractManager<Tap>
 {
+public:
+    virtual ~TapManager()
+    {
+    }
 };
 
 }

--- a/src/Taps.h
+++ b/src/Taps.h
@@ -1,0 +1,27 @@
+/* This Source Code Form is subject to the terms of the Mozilla Public
+ * License, v. 2.0. If a copy of the MPL was not distributed with this
+ * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
+
+#pragma once
+
+#include "Configurable.h"
+
+namespace visor {
+
+class Tap : public Configurable
+{
+protected:
+    /**
+     * the tap identifier: unique name associated with this Tap
+     */
+    std::string _name;
+
+public:
+    Tap(const std::string &name);
+};
+
+class TapManager
+{
+};
+
+}

--- a/src/Taps.h
+++ b/src/Taps.h
@@ -20,6 +20,10 @@ public:
         : AbstractModule(name)
     {
     }
+
+    void info_json(json &j) const override {
+        AbstractModule::_common_info_json(j);
+    }
 };
 
 class TapManager : public AbstractManager<Tap>

--- a/src/Taps.h
+++ b/src/Taps.h
@@ -7,7 +7,7 @@
 #include "AbstractManager.h"
 #include "AbstractModule.h"
 #include "Configurable.h"
-#include "InputStreamManager.h"
+#include "InputModulePlugin.h"
 #include <yaml-cpp/yaml.h>
 
 namespace visor {
@@ -25,11 +25,11 @@ public:
 class TapManager : public AbstractManager<Tap>
 {
 
-    const InputStreamManager *_input_manager;
+    const InputPluginRegistry *_input_plugin_registry;
 
 public:
-    TapManager(const InputStreamManager *inputManager)
-        : _input_manager(inputManager)
+    TapManager(const InputPluginRegistry *inputManager)
+        : _input_plugin_registry(inputManager)
     {
     }
 

--- a/src/Taps.h
+++ b/src/Taps.h
@@ -37,7 +37,7 @@ public:
     {
     }
 
-    void load(const YAML::Node &tap_yaml);
+    void load(const YAML::Node &tap_yaml, bool strict);
 };
 
 }

--- a/src/handlers/dns/DnsHandler.conf
+++ b/src/handlers/dns/DnsHandler.conf
@@ -1,2 +1,4 @@
+# Aliases
+provides=dns
 [data]
 desc=DNS analyzer

--- a/src/handlers/dns/DnsHandlerModulePlugin.cpp
+++ b/src/handlers/dns/DnsHandlerModulePlugin.cpp
@@ -16,10 +16,10 @@ namespace visor::handler::dns {
 using namespace visor::input::pcap;
 using json = nlohmann::json;
 
-void DnsHandlerModulePlugin::_setup_routes(HttpServer &svr)
+void DnsHandlerModulePlugin::_setup_routes(HttpServer *svr)
 {
     // CREATE
-    svr.Post("/api/v1/inputs/pcap/(\\w+)/handlers/dns", [this](const httplib::Request &req, httplib::Response &res) {
+    svr->Post("/api/v1/inputs/pcap/(\\w+)/handlers/dns", [this](const httplib::Request &req, httplib::Response &res) {
         json result;
         try {
             auto body = json::parse(req.body);
@@ -84,7 +84,7 @@ void DnsHandlerModulePlugin::_setup_routes(HttpServer &svr)
             res.set_content(result.dump(), "text/json");
         }
     });
-    svr.Get("/api/v1/inputs/pcap/(\\w+)/handlers/dns/(\\w+)", [this](const httplib::Request &req, httplib::Response &res) {
+    svr->Get("/api/v1/inputs/pcap/(\\w+)/handlers/dns/(\\w+)", [this](const httplib::Request &req, httplib::Response &res) {
         json result;
         try {
             auto input_name = req.matches[1];
@@ -117,7 +117,7 @@ void DnsHandlerModulePlugin::_setup_routes(HttpServer &svr)
             res.set_content(result.dump(), "text/json");
         }
     });
-    svr.Get("/api/v1/inputs/pcap/(\\w+)/handlers/dns/(\\w+)/bucket/(\\d+)", [this](const httplib::Request &req, httplib::Response &res) {
+    svr->Get("/api/v1/inputs/pcap/(\\w+)/handlers/dns/(\\w+)/bucket/(\\d+)", [this](const httplib::Request &req, httplib::Response &res) {
         json result;
         try {
             auto input_name = req.matches[1];
@@ -151,7 +151,7 @@ void DnsHandlerModulePlugin::_setup_routes(HttpServer &svr)
         }
     });
     // DELETE
-    svr.Delete("/api/v1/inputs/pcap/(\\w+)/handlers/dns/(\\w+)", [this](const httplib::Request &req, httplib::Response &res) {
+    svr->Delete("/api/v1/inputs/pcap/(\\w+)/handlers/dns/(\\w+)", [this](const httplib::Request &req, httplib::Response &res) {
         json result;
         try {
             auto input_name = req.matches[1];

--- a/src/handlers/dns/DnsHandlerModulePlugin.cpp
+++ b/src/handlers/dns/DnsHandlerModulePlugin.cpp
@@ -9,7 +9,7 @@
 #include <nlohmann/json.hpp>
 
 CORRADE_PLUGIN_REGISTER(VisorHandlerDns, visor::handler::dns::DnsHandlerModulePlugin,
-    "dev.visor.module.handler/1.0")
+    "visor.module.handler/1.0")
 
 namespace visor::handler::dns {
 

--- a/src/handlers/dns/DnsHandlerModulePlugin.h
+++ b/src/handlers/dns/DnsHandlerModulePlugin.h
@@ -19,11 +19,6 @@ public:
         : visor::HandlerModulePlugin{manager, plugin}
     {
     }
-
-    std::string name() const override
-    {
-        return "dns";
-    }
 };
 }
 

--- a/src/handlers/dns/DnsHandlerModulePlugin.h
+++ b/src/handlers/dns/DnsHandlerModulePlugin.h
@@ -22,7 +22,7 @@ public:
 
     std::string name() const override
     {
-        return "DnsHandler";
+        return "dns";
     }
 };
 }

--- a/src/handlers/dns/DnsHandlerModulePlugin.h
+++ b/src/handlers/dns/DnsHandlerModulePlugin.h
@@ -12,7 +12,7 @@ class DnsHandlerModulePlugin : public HandlerModulePlugin
 {
 
 protected:
-    void _setup_routes(HttpServer &svr) override;
+    void _setup_routes(HttpServer *svr) override;
 
 public:
     explicit DnsHandlerModulePlugin(Corrade::PluginManager::AbstractManager &manager, const std::string &plugin)

--- a/src/handlers/net/NetHandler.conf
+++ b/src/handlers/net/NetHandler.conf
@@ -1,2 +1,4 @@
+# Aliases
+provides=net
 [data]
 desc=Network (L3-L4) analyzer

--- a/src/handlers/net/NetHandlerModulePlugin.cpp
+++ b/src/handlers/net/NetHandlerModulePlugin.cpp
@@ -16,10 +16,10 @@ namespace visor::handler::net {
 using namespace visor::input::pcap;
 using json = nlohmann::json;
 
-void NetHandlerModulePlugin::_setup_routes(HttpServer &svr)
+void NetHandlerModulePlugin::_setup_routes(HttpServer *svr)
 {
     // CREATE
-    svr.Post("/api/v1/inputs/pcap/(\\w+)/handlers/net", [this](const httplib::Request &req, httplib::Response &res) {
+    svr->Post("/api/v1/inputs/pcap/(\\w+)/handlers/net", [this](const httplib::Request &req, httplib::Response &res) {
         json result;
         try {
             auto body = json::parse(req.body);
@@ -85,7 +85,7 @@ void NetHandlerModulePlugin::_setup_routes(HttpServer &svr)
             res.set_content(result.dump(), "text/json");
         }
     });
-    svr.Get("/api/v1/inputs/pcap/(\\w+)/handlers/net/(\\w+)", [this](const httplib::Request &req, httplib::Response &res) {
+    svr->Get("/api/v1/inputs/pcap/(\\w+)/handlers/net/(\\w+)", [this](const httplib::Request &req, httplib::Response &res) {
         json result;
         try {
             auto input_name = req.matches[1];
@@ -119,7 +119,7 @@ void NetHandlerModulePlugin::_setup_routes(HttpServer &svr)
             res.set_content(result.dump(), "text/json");
         }
     });
-    svr.Get("/api/v1/inputs/pcap/(\\w+)/handlers/net/(\\w+)/bucket/(\\d+)", [this](const httplib::Request &req, httplib::Response &res) {
+    svr->Get("/api/v1/inputs/pcap/(\\w+)/handlers/net/(\\w+)/bucket/(\\d+)", [this](const httplib::Request &req, httplib::Response &res) {
         json result;
         try {
             auto input_name = req.matches[1];
@@ -154,7 +154,7 @@ void NetHandlerModulePlugin::_setup_routes(HttpServer &svr)
         }
     });
     // DELETE
-    svr.Delete("/api/v1/inputs/pcap/(\\w+)/handlers/net/(\\w+)", [this](const httplib::Request &req, httplib::Response &res) {
+    svr->Delete("/api/v1/inputs/pcap/(\\w+)/handlers/net/(\\w+)", [this](const httplib::Request &req, httplib::Response &res) {
         json result;
         try {
             auto input_name = req.matches[1];

--- a/src/handlers/net/NetHandlerModulePlugin.cpp
+++ b/src/handlers/net/NetHandlerModulePlugin.cpp
@@ -9,7 +9,7 @@
 #include <nlohmann/json.hpp>
 
 CORRADE_PLUGIN_REGISTER(VisorHandlerNet, visor::handler::net::NetHandlerModulePlugin,
-    "dev.visor.module.handler/1.0")
+    "visor.module.handler/1.0")
 
 namespace visor::handler::net {
 

--- a/src/handlers/net/NetHandlerModulePlugin.h
+++ b/src/handlers/net/NetHandlerModulePlugin.h
@@ -23,7 +23,7 @@ public:
 
     std::string name() const override
     {
-        return "NetHandler";
+        return "net";
     }
 };
 }

--- a/src/handlers/net/NetHandlerModulePlugin.h
+++ b/src/handlers/net/NetHandlerModulePlugin.h
@@ -21,10 +21,6 @@ public:
     {
     }
 
-    std::string name() const override
-    {
-        return "net";
-    }
 };
 }
 

--- a/src/handlers/net/NetHandlerModulePlugin.h
+++ b/src/handlers/net/NetHandlerModulePlugin.h
@@ -13,7 +13,7 @@ class NetHandlerModulePlugin : public HandlerModulePlugin
 {
 
 protected:
-    void _setup_routes(HttpServer &svr) override;
+    void _setup_routes(HttpServer *svr) override;
 
 public:
     explicit NetHandlerModulePlugin(Corrade::PluginManager::AbstractManager &manager, const std::string &plugin)

--- a/src/inputs/pcap/PcapInput.conf
+++ b/src/inputs/pcap/PcapInput.conf
@@ -1,2 +1,4 @@
+# Aliases
+provides=pcap
 [data]
-desc=packet capture stream input (libpcap,DPDK,PF_RING)
+desc=packet capture stream input

--- a/src/inputs/pcap/PcapInputModulePlugin.cpp
+++ b/src/inputs/pcap/PcapInputModulePlugin.cpp
@@ -60,8 +60,8 @@ void PcapInputModulePlugin::_create(const httplib::Request &req, httplib::Respon
             if (body.contains("pcap_source")) {
                 input_stream->config_set("pcap_source", body["pcap_source"].get<std::string>());
             }
+            input_stream->start();
             _input_manager->module_add(std::move(input_stream));
-            // the module is now started and owned by the manager
         }
 
         auto [input_stream, stream_mgr_lock] = _input_manager->module_get_locked(body["name"]);

--- a/src/inputs/pcap/PcapInputModulePlugin.cpp
+++ b/src/inputs/pcap/PcapInputModulePlugin.cpp
@@ -11,17 +11,17 @@ CORRADE_PLUGIN_REGISTER(VisorInputPcap, visor::input::pcap::PcapInputModulePlugi
 
 namespace visor::input::pcap {
 
-void PcapInputModulePlugin::_setup_routes(HttpServer &svr)
+void PcapInputModulePlugin::_setup_routes(HttpServer *svr)
 {
 
     // CREATE
-    svr.Post("/api/v1/inputs/pcap", std::bind(&PcapInputModulePlugin::_create, this, std::placeholders::_1, std::placeholders::_2));
+    svr->Post("/api/v1/inputs/pcap", std::bind(&PcapInputModulePlugin::_create, this, std::placeholders::_1, std::placeholders::_2));
 
     // DELETE
-    svr.Delete("/api/v1/inputs/pcap/(\\w+)", std::bind(&PcapInputModulePlugin::_delete, this, std::placeholders::_1, std::placeholders::_2));
+    svr->Delete("/api/v1/inputs/pcap/(\\w+)", std::bind(&PcapInputModulePlugin::_delete, this, std::placeholders::_1, std::placeholders::_2));
 
     // GET
-    svr.Get("/api/v1/inputs/pcap/(\\w+)", std::bind(&PcapInputModulePlugin::_read, this, std::placeholders::_1, std::placeholders::_2));
+    svr->Get("/api/v1/inputs/pcap/(\\w+)", std::bind(&PcapInputModulePlugin::_read, this, std::placeholders::_1, std::placeholders::_2));
 }
 
 void PcapInputModulePlugin::_create(const httplib::Request &req, httplib::Response &res)

--- a/src/inputs/pcap/PcapInputModulePlugin.cpp
+++ b/src/inputs/pcap/PcapInputModulePlugin.cpp
@@ -7,7 +7,7 @@
 #include <Corrade/Utility/FormatStl.h>
 
 CORRADE_PLUGIN_REGISTER(VisorInputPcap, visor::input::pcap::PcapInputModulePlugin,
-    "dev.visor.module.input/1.0")
+    "visor.module.input/1.0")
 
 namespace visor::input::pcap {
 

--- a/src/inputs/pcap/PcapInputModulePlugin.h
+++ b/src/inputs/pcap/PcapInputModulePlugin.h
@@ -25,11 +25,6 @@ public:
         : visor::InputModulePlugin{manager, plugin}
     {
     }
-
-    std::string name() const override
-    {
-        return "pcap";
-    }
 };
 
 }

--- a/src/inputs/pcap/PcapInputModulePlugin.h
+++ b/src/inputs/pcap/PcapInputModulePlugin.h
@@ -28,7 +28,7 @@ public:
 
     std::string name() const override
     {
-        return "PcapInputModulePlugin";
+        return "pcap";
     }
 };
 

--- a/src/inputs/pcap/PcapInputModulePlugin.h
+++ b/src/inputs/pcap/PcapInputModulePlugin.h
@@ -14,7 +14,7 @@ class PcapInputModulePlugin : public visor::InputModulePlugin
 {
 
 protected:
-    void _setup_routes(HttpServer &svr) override;
+    void _setup_routes(HttpServer *svr) override;
 
     void _create(const httplib::Request &req, httplib::Response &res);
     void _read(const httplib::Request &req, httplib::Response &res);

--- a/src/tests/test_taps.cpp
+++ b/src/tests/test_taps.cpp
@@ -1,0 +1,70 @@
+#include "CoreManagers.h"
+#include "InputModulePlugin.h"
+#include "inputs/static_plugins.h"
+#include <catch2/catch.hpp>
+#include <spdlog/sinks/stdout_color_sinks.h>
+#include <spdlog/spdlog.h>
+
+using namespace visor;
+
+auto sample_config = R"(
+version: "1.0"
+
+visor:
+  config:
+    verbose: true
+  taps:
+    wired:
+      input_type: pcap
+      config:
+        iface: en7
+        number: 123
+        boolean: true
+    wireless:
+      input_type: pcap
+      config:
+        iface: en0
+)";
+
+auto sample_config_bad = R"(
+version: "1.0"
+
+visor:
+  config:
+    verbose: true
+  taps:
+    wired:
+      input_type: nonexistent
+      config:
+        iface: en7
+)";
+
+TEST_CASE("Taps", "[taps]")
+{
+
+    SECTION("Good Config")
+    {
+        CoreManagers mgrs(nullptr);
+        YAML::Node config_file = YAML::Load(sample_config);
+
+        CHECK(config_file["visor"]["taps"]);
+        CHECK(config_file["visor"]["taps"].IsMap());
+        CHECK_NOTHROW(mgrs.tap_manager()->load(config_file["visor"]["taps"], true));
+
+        auto [tap, lock] = mgrs.tap_manager()->module_get_locked("wired");
+        CHECK(tap->name() == "wired");
+        CHECK(tap->config_get<std::string>("iface") == "en7");
+        CHECK(tap->config_get<uint64_t>("number") == 123);
+        CHECK(tap->config_get<bool>("boolean") == true);
+    }
+
+    SECTION("Bad Config")
+    {
+        CoreManagers mgrs(nullptr);
+        YAML::Node config_file = YAML::Load(sample_config_bad);
+
+        CHECK(config_file["visor"]["taps"]);
+        CHECK(config_file["visor"]["taps"].IsMap());
+        CHECK_THROWS(mgrs.tap_manager()->load(config_file["visor"]["taps"], true));
+    }
+}


### PR DESCRIPTION
- Implements RFC #75 
- Adds YAML configuration files
- Adds https://github.com/fmtlib/fmt to conan directly (was already a dependency of spdlog)
- Adjust plug in naming scheme
- Module and metric labels are tracked more strictly with regex
- Remove module life cycle from abstract module manager
- Refactors `CoreManagers` out of `CoreServer`
- logging namespace changed to `visor` (from `pktvisor`)