### PR TITLE
require policy tap input_type

### DIFF
--- a/RFCs/2021-04-16-76-collection-policies.md
+++ b/RFCs/2021-04-16-76-collection-policies.md
@@ -20,8 +20,8 @@ visor:
       input:
         # this must reference a tap name, or application of the policy will fail
         tap: anycast
-        # this must match the type of the matching tap name. or application of the policy will fail
-        type: pcap
+        # this must match the input_type of the matching tap name, or application of the policy will fail
+        input_type: pcap
         config:
           bpf: "port 53"
       # stream handlers to attach to this input stream

--- a/src/Taps.h
+++ b/src/Taps.h
@@ -30,6 +30,11 @@ public:
 
     std::unique_ptr<InputStream> instantiate(Policy *policy, const Configurable *filter_config);
 
+    const InputModulePlugin *input_plugin() const
+    {
+        return _input_plugin;
+    }
+
     void info_json(json &j) const override
     {
         j["input_type"] = _input_plugin->plugin();


### PR DESCRIPTION
* require input_type to be defined on both tap and policy input tap, and that they match.