### PR TITLE
PcapPlusPlus interface concurrency

### DIFF
--- a/src/inputs/pcap/PcapInputStream.h
+++ b/src/inputs/pcap/PcapInputStream.h
@@ -48,7 +48,7 @@ private:
     PcapSource _cur_pcap_source{PcapSource::unknown};
 
     // libpcap source
-    pcpp::PcapLiveDevice *_pcapDevice = nullptr; // non owning
+    std::unique_ptr<pcpp::PcapLiveDevice> _pcapDevice;
     bool _pcapFile = false;
 
 #ifdef __linux__


### PR DESCRIPTION
Begin requiring NS1 fork of PcapPlusPlus to use PcapLiveDevice constructor directly rather than a singleton per interface. this enables capturing on the same device multiple times with different bpf.