### PR TITLE
Feature/133 mock traffic

### DIFF
--- a/src/inputs/pcap/CMakeLists.txt
+++ b/src/inputs/pcap/CMakeLists.txt
@@ -28,6 +28,7 @@ set(VISOR_STATIC_PLUGINS ${VISOR_STATIC_PLUGINS} Visor::Input::Pcap PARENT_SCOPE
 ## TEST SUITE
 add_executable(unit-tests-input-pcap
         tests/main.cpp
+        tests/test_mock_traffic.cpp
         tests/test_parse_pcap.cpp
         tests/test_utils.cpp
         )

--- a/src/inputs/pcap/PcapInputStream.cpp
+++ b/src/inputs/pcap/PcapInputStream.cpp
@@ -317,8 +317,8 @@ void PcapInputStream::_generate_mock_traffic()
     pcpp::Packet packet(newPacket.getRawPacket());
     pcpp::ProtocolType l3 = pcpp::IPv4;
     pcpp::ProtocolType l4 = pcpp::UDP;
-    std::timespec ts;
-    std::timespec_get(&ts, TIME_UTC);
+    timespec ts;
+    timespec_get(&ts, TIME_UTC);
     packet_signal(packet, dir, l3, l4, ts);
     udp_signal(packet, dir, l3, pcpp::hash5Tuple(&packet), ts);
 }

--- a/src/inputs/pcap/PcapInputStream.cpp
+++ b/src/inputs/pcap/PcapInputStream.cpp
@@ -192,6 +192,7 @@ void PcapInputStream::start()
         _mock_generator_thread = std::make_unique<std::thread>([this] {
             while (_running) {
                 _generate_mock_traffic();
+                // 10 qps. could be configurable in future.
                 std::this_thread::sleep_for(100ms);
             }
         });

--- a/src/inputs/pcap/PcapInputStream.h
+++ b/src/inputs/pcap/PcapInputStream.h
@@ -27,7 +27,8 @@ namespace visor::input::pcap {
 enum class PcapSource {
     unknown,
     libpcap,
-    af_packet
+    af_packet,
+    mock
 };
 
 enum class PacketDirection {
@@ -51,6 +52,9 @@ private:
     std::unique_ptr<pcpp::PcapLiveDevice> _pcapDevice;
     bool _pcapFile = false;
 
+    // mock source
+    std::unique_ptr<std::thread> _mock_generator_thread;
+
 #ifdef __linux__
     // af_packet source
     std::unique_ptr<AFPacket> _af_device;
@@ -62,6 +66,7 @@ protected:
     void _open_pcap(const std::string &fileName, const std::string &bpfFilter);
     void _open_libpcap_iface(const std::string &bpfFilter = "");
     void _get_hosts_from_libpcap_iface();
+    void _generate_mock_traffic();
 
 #ifdef __linux__
     void _open_af_packet_iface(const std::string &iface, const std::string &bpfFilter);

--- a/src/inputs/pcap/tests/test_mock_traffic.cpp
+++ b/src/inputs/pcap/tests/test_mock_traffic.cpp
@@ -1,0 +1,21 @@
+#include "PcapInputStream.h"
+#include <arpa/inet.h>
+#include <catch2/catch.hpp>
+
+using namespace visor::input::pcap;
+using namespace std::chrono;
+
+TEST_CASE("Test mock traffic generator", "[pcap][mock]")
+{
+
+    PcapInputStream stream{"pcap-test"};
+    stream.config_set("host_spec", "192.168.0.0/24");
+    stream.config_set("pcap_source", "mock");
+    stream.parse_host_spec();
+
+    stream.start();
+    std::this_thread::sleep_for(1s);
+    stream.stop();
+
+}
+


### PR DESCRIPTION
Add `mock` pcap source, which generates mock DNS traffic instead of capturing