### PR TITLE
clang toolchain builds, statically linked executables

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -8,3 +8,4 @@ appimage/Dockerfile.part
 appimage/export.sh
 appimage/Makefile
 localconfig/*
+docker/*

--- a/.dockerignore
+++ b/.dockerignore
@@ -3,7 +3,6 @@ integration_tests/external*
 Dockerfile
 .dockerignore
 .gitignore
-.git
 appimage/Dockerfile.part
 appimage/export.sh
 appimage/Makefile

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,9 +23,9 @@ jobs:
     # See: https://docs.github.com/en/free-pro-team@latest/actions/learn-github-actions/managing-complex-workflows#using-a-build-matrix
     strategy:
       matrix:
-#        os: [ ubuntu-latest, macos-latest ]
+        os: [ ubuntu-latest, macos-latest ]
          # 1/5/21 bison fails to build on macos-latest only in github CI
-         os: [ ubuntu-latest ]
+#         os: [ ubuntu-latest ]
     runs-on: ${{ matrix.os }}
 
     steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,7 +23,9 @@ jobs:
     # See: https://docs.github.com/en/free-pro-team@latest/actions/learn-github-actions/managing-complex-workflows#using-a-build-matrix
     strategy:
       matrix:
-        os: [ ubuntu-latest, macos-latest ]
+#        os: [ ubuntu-latest, macos-latest ]
+         # 1/5/21 bison fails to build on macos-latest only in github CI
+         os: [ ubuntu-latest ]
     runs-on: ${{ matrix.os }}
 
     steps:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,28 +39,11 @@ jobs:
         # uses: turtlebrowser/get-conan@4dc7e6dd45c8b1e02e909979d7cfc5ebba6ddbe2
         uses: turtlebrowser/get-conan@v1.0
 
-      - name: Conan profile and settings
-        run: |
-          conan profile new --detect default
-          conan config set general.revisions_enabled=1
-
-      - name: Conan profile (linux-workaround)
-        if: matrix.os == 'ubuntu-latest'
-        run:
-          conan profile update settings.compiler.libcxx=libstdc++11 default
-
-      - name: Conan install (osx-workaround)
-        if: matrix.os == 'macos-latest'
-        working-directory: ${{github.workspace}}/build
-        run: |
-          conan remote add ns1labs-conan https://ns1labs.jfrog.io/artifactory/api/conan/ns1labs-conan
-          conan install --build=missing ..
-
       - name: linux package install
         if: matrix.os == 'ubuntu-latest'
         run: |
           sudo apt-get update
-          sudo apt-get install --yes --no-install-recommends golang ca-certificates jq
+          sudo apt-get install --yes --no-install-recommends jq
 
       - name: Configure CMake
         # Use a bash shell so we can use the same syntax for environment variable
@@ -99,12 +82,6 @@ jobs:
 
       - name: Get Conan
         uses: turtlebrowser/get-conan@v1.0
-
-      - name: Conan profile and settings
-        run: |
-          conan profile new --detect default
-          conan config set general.revisions_enabled=1
-          conan profile update settings.compiler.libcxx=libstdc++11 default
 
       - name: Configure CMake to generate VERSION
         shell: bash

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,8 +24,6 @@ jobs:
     strategy:
       matrix:
         os: [ ubuntu-latest, macos-latest ]
-         # 1/5/21 bison fails to build on macos-latest only in github CI
-#         os: [ ubuntu-latest ]
     runs-on: ${{ matrix.os }}
 
     steps:

--- a/.github/workflows/static_build.yml
+++ b/.github/workflows/static_build.yml
@@ -77,15 +77,28 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      - name: Build static pktvisord
-        if: github.event_name != 'pull_request'
+      - name: Build and package static pktvisord
+#        if: github.event_name != 'pull_request'
         env:
-          IMAGE_NAME: ns1labs/pktvisord
+          BASE_BINARY: pktvisord
+          IMAGE_NAME: ns1labs/${{ env.BASE_BINARY }}-slim
+          BINARY_NAME: ${{ env.BASE_BINARY }}-linux-x86_64-${{ env.VERSION }}
         run: |
-          docker build -f docker/Dockerfile.pktvisord-static -t ${{ env.IMAGE_NAME }} .
+          docker build -f docker/Dockerfile.${{ env.BASE_BINARY }}-static -t ${{ env.IMAGE_NAME }} .
           docker push -a ${{ env.IMAGE_NAME }}
+          echo "CONT_ID=$(docker create --name ${{ env.BASE_BINARY }}-slim-tmp ${{ env.IMAGE_NAME }})" >> $GITHUB_ENV
+          docker cp ${{ env.CONT_ID }}:/${{ env.BASE_BINARY }} ${{github.workspace}}/${{ env.BINARY_NAME }}
 
-      - name: Build static pktvisor-pcap
+      - name: Upload pktvisord artifact
+#        if: github.event_name != 'pull_request'
+        env:
+          BINARY_NAME: pktvisord-linux-x86_64-${{ env.VERSION }}
+        uses: actions/upload-artifact@v2
+        with:
+          name: ${{ env.BINARY_NAME }}
+          path: ${{github.workspace}}/${{ env.BINARY_NAME }}
+
+      - name: Build static pktvisor-pcap-slim
         if: github.event_name != 'pull_request'
         env:
           IMAGE_NAME: ns1labs/pktvisor-pcap
@@ -96,129 +109,8 @@ jobs:
       - name: Build static pktvisord-dnstap
         if: github.event_name != 'pull_request'
         env:
-          IMAGE_NAME: ns1labs/pktvisor-pcap
+          IMAGE_NAME: ns1labs/pktvisor-pcap-slim
         run: |
           docker build -f docker/Dockerfile.pktvisor-dnstap-static -t ${{ env.IMAGE_NAME }} .
           docker push -a ${{ env.IMAGE_NAME }}
 
-#  package:
-#    needs: build
-#    runs-on: ubuntu-latest
-#    # if this is a push into one of our main branches (rather than just a pull request), we will also package
-#    if: github.event_name != 'pull_request'
-#
-#    steps:
-#      - uses: actions/checkout@v2
-#
-#      - name: Create Build Environment
-#        run: cmake -E make_directory ${{github.workspace}}/build
-#
-#      - name: Get Conan
-#        uses: turtlebrowser/get-conan@v1.0
-#
-#      - name: Conan profile and settings
-#        run: |
-#          conan profile new --detect default
-#          conan config set general.revisions_enabled=1
-#          conan profile update settings.compiler.libcxx=libstdc++11 default
-#
-#      - name: Configure CMake to generate VERSION
-#        shell: bash
-#        working-directory: ${{github.workspace}}/build
-#        run: cmake $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=$BUILD_TYPE
-#
-#      - name: Get branch name
-#        shell: bash
-#        run: echo "BRANCH_NAME=$(echo ${GITHUB_REF#refs/heads/} | tr / -)" >> $GITHUB_ENV
-#
-#      - name: Debug branch name
-#        run: echo ${{ env.BRANCH_NAME }}
-#
-#      - name: Get VERSION
-#        run: |
-#          echo "VERSION=`cat ${{github.workspace}}/build/VERSION`" >> $GITHUB_ENV
-#
-#      - name: Debug version
-#        run: echo ${{ env.VERSION }}
-#
-#      - name: Generate ref tag (master)
-#        if: ${{ env.BRANCH_NAME == 'master' }}
-#        run: |
-#          echo "REF_TAG=latest" >> $GITHUB_ENV
-#          echo "PRERELEASE=false" >> $GITHUB_ENV
-#          echo "DRAFT=true" >> $GITHUB_ENV
-#
-#      - name: Generate ref tag (develop)
-#        if: ${{ env.BRANCH_NAME == 'develop' }}
-#        run: |
-#          echo "REF_TAG=latest-develop" >> $GITHUB_ENV
-#          echo "PRERELEASE=true" >> $GITHUB_ENV
-#          echo "DRAFT=false" >> $GITHUB_ENV
-#
-#      - name: Generate ref tag (release candidate)
-#        if: ${{ env.BRANCH_NAME == 'release' }}
-#        run: |
-#          echo "REF_TAG=latest-rc" >> $GITHUB_ENV
-#          echo "PRERELEASE=true" >> $GITHUB_ENV
-#          echo "DRAFT=false" >> $GITHUB_ENV
-#
-#      - name: Debug ref tag
-#        run: echo ${{ env.REF_TAG }}
-#
-#      - name: Manage Github ref tags
-#        uses: actions/github-script@v3
-#        with:
-#          github-token: ${{ github.token }}
-#          # note deleteRef can't start with refs/, but create createRef does.
-#          script: |
-#            try {
-#                await github.git.deleteRef({
-#                  owner: context.repo.owner,
-#                  repo: context.repo.repo,
-#                  ref: "tags/${{ env.REF_TAG }}",
-#                })
-#            } catch (e) {
-#              console.log("The tag doesn't exist yet: " + e)
-#            }
-#            await github.git.createRef({
-#              owner: context.repo.owner,
-#              repo: context.repo.repo,
-#              ref: "refs/tags/${{ env.REF_TAG }}",
-#              sha: context.sha
-#            })
-#
-#      - name: Login to Docker Hub
-#        uses: docker/login-action@v1
-#        with:
-#          username: ${{ secrets.DOCKERHUB_USERNAME }}
-#          password: ${{ secrets.DOCKERHUB_TOKEN }}
-#
-#      - name: Build + push - pktvisor
-#        env:
-#          IMAGE_NAME: ns1labs/pktvisor
-#        run: |
-#          docker build . --file docker/Dockerfile --tag ${{ env.IMAGE_NAME }}:${{ env.VERSION }} --tag ${{ env.IMAGE_NAME }}:${{ env.REF_TAG }}
-#          docker push -a ${{ env.IMAGE_NAME }}
-#
-#      - name: Build + push - pktvisor-prom-write
-#        env:
-#          IMAGE_NAME: ns1labs/pktvisor-prom-write
-#        working-directory: ${{github.workspace}}/centralized_collection/prometheus/docker-grafana-agent
-#        run: |
-#          docker build . --file Dockerfile --build-arg PKTVISOR_TAG=${{ env.REF_TAG }} --tag ${{ env.IMAGE_NAME }}:${{ env.VERSION }} --tag ${{ env.IMAGE_NAME }}:${{ env.REF_TAG }}
-#          docker push -a ${{ env.IMAGE_NAME }}
-#
-#      - name: Generate AppImage
-#        env:
-#          IMAGE_NAME: ns1labs/pktvisor
-#        working-directory: ${{github.workspace}}/appimage
-#        run: |
-#          DEV_IMAGE="${{ env.IMAGE_NAME }}:${{ env.VERSION }}" DEV_MODE=t make pktvisor-x86_64.AppImage
-#          mv pktvisor-x86_64.AppImage pktvisor-x86_64-${{ env.VERSION }}.AppImage
-#
-#      - name: Upload AppImage artifact
-#        uses: actions/upload-artifact@v2
-#        with:
-#          name: pktvisor-x86_64-${{ env.VERSION }}.AppImage
-#          path: ${{github.workspace}}/appimage/pktvisor-x86_64-${{ env.VERSION }}.AppImage
-#

--- a/.github/workflows/static_build.yml
+++ b/.github/workflows/static_build.yml
@@ -33,11 +33,6 @@ jobs:
         run: |
           docker build -f docker/Dockerfile.static-base -t ns1labs/static-base .
 
-      - name: Configure CMake to generate VERSION
-        shell: bash
-        working-directory: ${{github.workspace}}/build
-        run: cmake $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=$BUILD_TYPE
-
       - name: Get branch name
         shell: bash
         run: echo "BRANCH_NAME=$(echo ${GITHUB_REF#refs/heads/} | tr / -)" >> $GITHUB_ENV
@@ -47,7 +42,7 @@ jobs:
 
       - name: Get VERSION
         run: |
-          echo "VERSION=`cat ${{github.workspace}}/build/VERSION`" >> $GITHUB_ENV
+          echo "VERSION=`docker run --rm -a stdout --entrypoint cat ns1labs/static-base VERSION`" >> $GITHUB_ENV
 
       - name: Debug version
         run: echo ${{ env.VERSION }}

--- a/.github/workflows/static_build.yml
+++ b/.github/workflows/static_build.yml
@@ -86,6 +86,8 @@ jobs:
           docker build -f docker/Dockerfile.${{ env.BASE_BINARY }}-static -t ${{ env.IMAGE_NAME }} .
           docker push -a ${{ env.IMAGE_NAME }}
           echo "CONT_ID=$(docker create --name ${{ env.BASE_BINARY }}-slim-tmp ${{ env.IMAGE_NAME }})" >> $GITHUB_ENV
+          echo "cont_id: ${{ env.CONT_ID }}"
+          docker create --name ${{ env.BASE_BINARY }}-slim-tmp ${{ env.IMAGE_NAME }} 
           docker cp ${{ env.CONT_ID }}:/${{ env.BASE_BINARY }} ${{github.workspace}}/pktvisord-linux-x86_64-${{ env.VERSION }}
 
       - name: Upload pktvisord artifact

--- a/.github/workflows/static_build.yml
+++ b/.github/workflows/static_build.yml
@@ -77,7 +77,7 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      - name: Build and package static pktvisord
+      - name: Build and push static pktvisord container
 #        if: github.event_name != 'pull_request'
         env:
           BASE_BINARY: pktvisord
@@ -86,9 +86,13 @@ jobs:
           docker build -f docker/Dockerfile.${{ env.BASE_BINARY }}-static -t ${{ env.IMAGE_NAME }} .
           docker push -a ${{ env.IMAGE_NAME }}
           echo "CONT_ID=$(docker create --name ${{ env.BASE_BINARY }}-slim-tmp ${{ env.IMAGE_NAME }})" >> $GITHUB_ENV
-          echo "cont_id: ${{ env.CONT_ID }}"
-          docker create --name ${{ env.BASE_BINARY }}-slim-tmp ${{ env.IMAGE_NAME }} 
-          docker cp ${{ env.CONT_ID }}:/${{ env.BASE_BINARY }} ${{github.workspace}}/pktvisord-linux-x86_64-${{ env.VERSION }}
+
+      - name: Extract static pktvisord asset
+        env:
+          BASE_BINARY: pktvisord
+          IMAGE_NAME: ns1labs/pktvisord-slim
+        run: |
+          docker cp ${{ env.CONT_ID }}:/${{ env.BASE_BINARY }} ${{github.workspace}}/${{ env.BASE_BINARY }}-linux-x86_64-${{ env.VERSION }}
 
       - name: Upload pktvisord artifact
 #        if: github.event_name != 'pull_request'

--- a/.github/workflows/static_build.yml
+++ b/.github/workflows/static_build.yml
@@ -78,7 +78,7 @@ jobs:
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Build and push static pktvisord container
-#        if: github.event_name != 'pull_request'
+        if: github.event_name != 'pull_request'
         env:
           BASE_BINARY: pktvisord
           IMAGE_NAME: ns1labs/pktvisord-slim
@@ -88,6 +88,7 @@ jobs:
           echo "CONT_ID=$(docker create --name ${{ env.BASE_BINARY }}-slim-tmp ${{ env.IMAGE_NAME }})" >> $GITHUB_ENV
 
       - name: Extract static pktvisord asset
+        if: github.event_name != 'pull_request'
         env:
           BASE_BINARY: pktvisord
           IMAGE_NAME: ns1labs/pktvisord-slim
@@ -95,7 +96,7 @@ jobs:
           docker cp ${{ env.CONT_ID }}:/${{ env.BASE_BINARY }} ${{github.workspace}}/${{ env.BASE_BINARY }}-linux-x86_64-${{ env.VERSION }}
 
       - name: Upload pktvisord artifact
-#        if: github.event_name != 'pull_request'
+        if: github.event_name != 'pull_request'
         env:
           BINARY_NAME: pktvisord-linux-x86_64-${{ env.VERSION }}
         uses: actions/upload-artifact@v2
@@ -103,19 +104,59 @@ jobs:
           name: ${{ env.BINARY_NAME }}
           path: ${{github.workspace}}/${{ env.BINARY_NAME }}
 
-      - name: Build static pktvisor-pcap-slim
+      - name: Build and push static pktvisor-pcap container
         if: github.event_name != 'pull_request'
         env:
-          IMAGE_NAME: ns1labs/pktvisor-pcap
-        run: |
-          docker build -f docker/Dockerfile.pktvisor-pcap-static -t ${{ env.IMAGE_NAME }} .
-          docker push -a ${{ env.IMAGE_NAME }}
-
-      - name: Build static pktvisord-dnstap
-        if: github.event_name != 'pull_request'
-        env:
+          BASE_BINARY: pktvisor-pcap
           IMAGE_NAME: ns1labs/pktvisor-pcap-slim
         run: |
-          docker build -f docker/Dockerfile.pktvisor-dnstap-static -t ${{ env.IMAGE_NAME }} .
+          docker build -f docker/Dockerfile.${{ env.BASE_BINARY }}-static -t ${{ env.IMAGE_NAME }} .
           docker push -a ${{ env.IMAGE_NAME }}
+          echo "CONT_ID=$(docker create --name ${{ env.BASE_BINARY }}-slim-tmp ${{ env.IMAGE_NAME }})" >> $GITHUB_ENV
+
+      - name: Extract static pktvisor-pcap asset
+        if: github.event_name != 'pull_request'
+        env:
+          BASE_BINARY: pktvisor-pcap
+          IMAGE_NAME: ns1labs/pktvisor-pcap-slim
+        run: |
+          docker cp ${{ env.CONT_ID }}:/${{ env.BASE_BINARY }} ${{github.workspace}}/${{ env.BASE_BINARY }}-linux-x86_64-${{ env.VERSION }}
+
+      - name: Upload pktvisor-pcap artifact
+        if: github.event_name != 'pull_request'
+        env:
+          BINARY_NAME: pktvisor-pcap-linux-x86_64-${{ env.VERSION }}
+        uses: actions/upload-artifact@v2
+        with:
+          name: ${{ env.BINARY_NAME }}
+          path: ${{github.workspace}}/${{ env.BINARY_NAME }}
+
+
+      - name: Build and push static pktvisor-dnstap container
+        if: github.event_name != 'pull_request'
+        env:
+          BASE_BINARY: pktvisor-dnstap
+          IMAGE_NAME: ns1labs/pktvisor-dnstap-slim
+        run: |
+          docker build -f docker/Dockerfile.${{ env.BASE_BINARY }}-static -t ${{ env.IMAGE_NAME }} .
+          docker push -a ${{ env.IMAGE_NAME }}
+          echo "CONT_ID=$(docker create --name ${{ env.BASE_BINARY }}-slim-tmp ${{ env.IMAGE_NAME }})" >> $GITHUB_ENV
+
+      - name: Extract static pktvisor-dnstap asset
+        if: github.event_name != 'pull_request'
+        env:
+          BASE_BINARY: pktvisor-dnstap
+          IMAGE_NAME: ns1labs/pktvisor-dnstap-slim
+        run: |
+          docker cp ${{ env.CONT_ID }}:/${{ env.BASE_BINARY }} ${{github.workspace}}/${{ env.BASE_BINARY }}-linux-x86_64-${{ env.VERSION }}
+
+      - name: Upload pktvisor-dnstap artifact
+        if: github.event_name != 'pull_request'
+        env:
+          BINARY_NAME: pktvisor-dnstap-linux-x86_64-${{ env.VERSION }}
+        uses: actions/upload-artifact@v2
+        with:
+          name: ${{ env.BINARY_NAME }}
+          path: ${{github.workspace}}/${{ env.BINARY_NAME }}
+
 

--- a/.github/workflows/static_build.yml
+++ b/.github/workflows/static_build.yml
@@ -48,30 +48,26 @@ jobs:
         run: echo ${{ env.VERSION }}
 
       - name: Generate ref tag (master)
-        if: ${{ env.BRANCH_NAME == 'master' }}
+        if: github.event_name != 'pull_request' && ${{ env.BRANCH_NAME == 'master' }}
         run: |
           echo "REF_TAG=latest" >> $GITHUB_ENV
-          echo "PRERELEASE=false" >> $GITHUB_ENV
-          echo "DRAFT=true" >> $GITHUB_ENV
 
       - name: Generate ref tag (develop)
-        if: ${{ env.BRANCH_NAME == 'develop' }}
+        if: github.event_name != 'pull_request' && ${{ env.BRANCH_NAME == 'develop' }}
         run: |
           echo "REF_TAG=latest-develop" >> $GITHUB_ENV
-          echo "PRERELEASE=true" >> $GITHUB_ENV
-          echo "DRAFT=false" >> $GITHUB_ENV
 
       - name: Generate ref tag (release candidate)
-        if: ${{ env.BRANCH_NAME == 'release' }}
+        if: github.event_name != 'pull_request' && ${{ env.BRANCH_NAME == 'release' }}
         run: |
           echo "REF_TAG=latest-rc" >> $GITHUB_ENV
-          echo "PRERELEASE=true" >> $GITHUB_ENV
-          echo "DRAFT=false" >> $GITHUB_ENV
 
       - name: Debug ref tag
+        if: github.event_name != 'pull_request'
         run: echo ${{ env.REF_TAG }}
 
       - name: Login to Docker Hub
+        if: github.event_name != 'pull_request'
         uses: docker/login-action@v1
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
@@ -83,9 +79,9 @@ jobs:
           BASE_BINARY: pktvisord
           IMAGE_NAME: ns1labs/pktvisord-slim
         run: |
-          docker build -f docker/Dockerfile.${{ env.BASE_BINARY }}-static -t ${{ env.IMAGE_NAME }} .
+          docker build -f docker/Dockerfile.${{ env.BASE_BINARY }}-static -t ${{ env.IMAGE_NAME }}:${{ env.REF_TAG }} -t ${{ env.IMAGE_NAME }}:${{ env.VERSION }} .
           docker push -a ${{ env.IMAGE_NAME }}
-          echo "CONT_ID=$(docker create --name ${{ env.BASE_BINARY }}-slim-tmp ${{ env.IMAGE_NAME }})" >> $GITHUB_ENV
+          echo "CONT_ID=$(docker create --name ${{ env.BASE_BINARY }}-slim-tmp ${{ env.IMAGE_NAME }}:${{ env.REF_TAG }})" >> $GITHUB_ENV
 
       - name: Extract static pktvisord asset
         if: github.event_name != 'pull_request'
@@ -110,9 +106,9 @@ jobs:
           BASE_BINARY: pktvisor-pcap
           IMAGE_NAME: ns1labs/pktvisor-pcap-slim
         run: |
-          docker build -f docker/Dockerfile.${{ env.BASE_BINARY }}-static -t ${{ env.IMAGE_NAME }} .
+          docker build -f docker/Dockerfile.${{ env.BASE_BINARY }}-static -t ${{ env.IMAGE_NAME }}:${{ env.REF_TAG }} -t ${{ env.IMAGE_NAME }}:${{ env.VERSION }} .
           docker push -a ${{ env.IMAGE_NAME }}
-          echo "CONT_ID=$(docker create --name ${{ env.BASE_BINARY }}-slim-tmp ${{ env.IMAGE_NAME }})" >> $GITHUB_ENV
+          echo "CONT_ID=$(docker create --name ${{ env.BASE_BINARY }}-slim-tmp ${{ env.IMAGE_NAME }}:${{ env.REF_TAG }})" >> $GITHUB_ENV
 
       - name: Extract static pktvisor-pcap asset
         if: github.event_name != 'pull_request'
@@ -138,9 +134,9 @@ jobs:
           BASE_BINARY: pktvisor-dnstap
           IMAGE_NAME: ns1labs/pktvisor-dnstap-slim
         run: |
-          docker build -f docker/Dockerfile.${{ env.BASE_BINARY }}-static -t ${{ env.IMAGE_NAME }} .
+          docker build -f docker/Dockerfile.${{ env.BASE_BINARY }}-static -t ${{ env.IMAGE_NAME }}:${{ env.REF_TAG }} -t ${{ env.IMAGE_NAME }}:${{ env.VERSION }} .
           docker push -a ${{ env.IMAGE_NAME }}
-          echo "CONT_ID=$(docker create --name ${{ env.BASE_BINARY }}-slim-tmp ${{ env.IMAGE_NAME }})" >> $GITHUB_ENV
+          echo "CONT_ID=$(docker create --name ${{ env.BASE_BINARY }}-slim-tmp ${{ env.IMAGE_NAME }}:${{ env.REF_TAG }})" >> $GITHUB_ENV
 
       - name: Extract static pktvisor-dnstap asset
         if: github.event_name != 'pull_request'

--- a/.github/workflows/static_build.yml
+++ b/.github/workflows/static_build.yml
@@ -31,7 +31,7 @@ jobs:
 
       - name: Build and test static pktvisord
         run: |
-          docker build -v ${{github.workspace}}:/project -f docker/Dockerfile.clang-toolchain-build .
+          docker build -f docker/Dockerfile.clang-toolchain-build .
 
 #  package:
 #    needs: build

--- a/.github/workflows/static_build.yml
+++ b/.github/workflows/static_build.yml
@@ -1,0 +1,156 @@
+name: Static Build
+
+on:
+  workflow_dispatch:
+  pull_request:
+    branches:
+      - develop
+      - release
+  push:
+    branches:
+      - develop
+      - release
+
+env:
+  # Customize the CMake build type here (Release, Debug, RelWithDebInfo, etc.)
+  BUILD_TYPE: Release
+
+jobs:
+  build:
+    # The CMake configure and build commands are platform agnostic and should work equally
+    # well on Windows or Mac.  You can convert this to a matrix build if you need
+    # cross-platform coverage.
+    # See: https://docs.github.com/en/free-pro-team@latest/actions/learn-github-actions/managing-complex-workflows#using-a-build-matrix
+    strategy:
+      matrix:
+        os: [ ubuntu-latest ]
+    runs-on: ${{ matrix.os }}
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Build and test static pktvisord
+        run: |
+          docker build -v ${{github.workspace}}:/project -f docker/Dockerfile.clang-toolchain-build .
+
+#  package:
+#    needs: build
+#    runs-on: ubuntu-latest
+#    # if this is a push into one of our main branches (rather than just a pull request), we will also package
+#    if: github.event_name != 'pull_request'
+#
+#    steps:
+#      - uses: actions/checkout@v2
+#
+#      - name: Create Build Environment
+#        run: cmake -E make_directory ${{github.workspace}}/build
+#
+#      - name: Get Conan
+#        uses: turtlebrowser/get-conan@v1.0
+#
+#      - name: Conan profile and settings
+#        run: |
+#          conan profile new --detect default
+#          conan config set general.revisions_enabled=1
+#          conan profile update settings.compiler.libcxx=libstdc++11 default
+#
+#      - name: Configure CMake to generate VERSION
+#        shell: bash
+#        working-directory: ${{github.workspace}}/build
+#        run: cmake $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=$BUILD_TYPE
+#
+#      - name: Get branch name
+#        shell: bash
+#        run: echo "BRANCH_NAME=$(echo ${GITHUB_REF#refs/heads/} | tr / -)" >> $GITHUB_ENV
+#
+#      - name: Debug branch name
+#        run: echo ${{ env.BRANCH_NAME }}
+#
+#      - name: Get VERSION
+#        run: |
+#          echo "VERSION=`cat ${{github.workspace}}/build/VERSION`" >> $GITHUB_ENV
+#
+#      - name: Debug version
+#        run: echo ${{ env.VERSION }}
+#
+#      - name: Generate ref tag (master)
+#        if: ${{ env.BRANCH_NAME == 'master' }}
+#        run: |
+#          echo "REF_TAG=latest" >> $GITHUB_ENV
+#          echo "PRERELEASE=false" >> $GITHUB_ENV
+#          echo "DRAFT=true" >> $GITHUB_ENV
+#
+#      - name: Generate ref tag (develop)
+#        if: ${{ env.BRANCH_NAME == 'develop' }}
+#        run: |
+#          echo "REF_TAG=latest-develop" >> $GITHUB_ENV
+#          echo "PRERELEASE=true" >> $GITHUB_ENV
+#          echo "DRAFT=false" >> $GITHUB_ENV
+#
+#      - name: Generate ref tag (release candidate)
+#        if: ${{ env.BRANCH_NAME == 'release' }}
+#        run: |
+#          echo "REF_TAG=latest-rc" >> $GITHUB_ENV
+#          echo "PRERELEASE=true" >> $GITHUB_ENV
+#          echo "DRAFT=false" >> $GITHUB_ENV
+#
+#      - name: Debug ref tag
+#        run: echo ${{ env.REF_TAG }}
+#
+#      - name: Manage Github ref tags
+#        uses: actions/github-script@v3
+#        with:
+#          github-token: ${{ github.token }}
+#          # note deleteRef can't start with refs/, but create createRef does.
+#          script: |
+#            try {
+#                await github.git.deleteRef({
+#                  owner: context.repo.owner,
+#                  repo: context.repo.repo,
+#                  ref: "tags/${{ env.REF_TAG }}",
+#                })
+#            } catch (e) {
+#              console.log("The tag doesn't exist yet: " + e)
+#            }
+#            await github.git.createRef({
+#              owner: context.repo.owner,
+#              repo: context.repo.repo,
+#              ref: "refs/tags/${{ env.REF_TAG }}",
+#              sha: context.sha
+#            })
+#
+#      - name: Login to Docker Hub
+#        uses: docker/login-action@v1
+#        with:
+#          username: ${{ secrets.DOCKERHUB_USERNAME }}
+#          password: ${{ secrets.DOCKERHUB_TOKEN }}
+#
+#      - name: Build + push - pktvisor
+#        env:
+#          IMAGE_NAME: ns1labs/pktvisor
+#        run: |
+#          docker build . --file docker/Dockerfile --tag ${{ env.IMAGE_NAME }}:${{ env.VERSION }} --tag ${{ env.IMAGE_NAME }}:${{ env.REF_TAG }}
+#          docker push -a ${{ env.IMAGE_NAME }}
+#
+#      - name: Build + push - pktvisor-prom-write
+#        env:
+#          IMAGE_NAME: ns1labs/pktvisor-prom-write
+#        working-directory: ${{github.workspace}}/centralized_collection/prometheus/docker-grafana-agent
+#        run: |
+#          docker build . --file Dockerfile --build-arg PKTVISOR_TAG=${{ env.REF_TAG }} --tag ${{ env.IMAGE_NAME }}:${{ env.VERSION }} --tag ${{ env.IMAGE_NAME }}:${{ env.REF_TAG }}
+#          docker push -a ${{ env.IMAGE_NAME }}
+#
+#      - name: Generate AppImage
+#        env:
+#          IMAGE_NAME: ns1labs/pktvisor
+#        working-directory: ${{github.workspace}}/appimage
+#        run: |
+#          DEV_IMAGE="${{ env.IMAGE_NAME }}:${{ env.VERSION }}" DEV_MODE=t make pktvisor-x86_64.AppImage
+#          mv pktvisor-x86_64.AppImage pktvisor-x86_64-${{ env.VERSION }}.AppImage
+#
+#      - name: Upload AppImage artifact
+#        uses: actions/upload-artifact@v2
+#        with:
+#          name: pktvisor-x86_64-${{ env.VERSION }}.AppImage
+#          path: ${{github.workspace}}/appimage/pktvisor-x86_64-${{ env.VERSION }}.AppImage
+#

--- a/.github/workflows/static_build.yml
+++ b/.github/workflows/static_build.yml
@@ -29,9 +29,82 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - name: Build and test static pktvisord
+      - name: Build and test static base
         run: |
-          docker build -f docker/Dockerfile.pktvisord-static .
+          docker build -f docker/Dockerfile.static-base -t ns1labs/static-base .
+
+      - name: Configure CMake to generate VERSION
+        shell: bash
+        working-directory: ${{github.workspace}}/build
+        run: cmake $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=$BUILD_TYPE
+
+      - name: Get branch name
+        shell: bash
+        run: echo "BRANCH_NAME=$(echo ${GITHUB_REF#refs/heads/} | tr / -)" >> $GITHUB_ENV
+
+      - name: Debug branch name
+        run: echo ${{ env.BRANCH_NAME }}
+
+      - name: Get VERSION
+        run: |
+          echo "VERSION=`cat ${{github.workspace}}/build/VERSION`" >> $GITHUB_ENV
+
+      - name: Debug version
+        run: echo ${{ env.VERSION }}
+
+      - name: Generate ref tag (master)
+        if: ${{ env.BRANCH_NAME == 'master' }}
+        run: |
+          echo "REF_TAG=latest" >> $GITHUB_ENV
+          echo "PRERELEASE=false" >> $GITHUB_ENV
+          echo "DRAFT=true" >> $GITHUB_ENV
+
+      - name: Generate ref tag (develop)
+        if: ${{ env.BRANCH_NAME == 'develop' }}
+        run: |
+          echo "REF_TAG=latest-develop" >> $GITHUB_ENV
+          echo "PRERELEASE=true" >> $GITHUB_ENV
+          echo "DRAFT=false" >> $GITHUB_ENV
+
+      - name: Generate ref tag (release candidate)
+        if: ${{ env.BRANCH_NAME == 'release' }}
+        run: |
+          echo "REF_TAG=latest-rc" >> $GITHUB_ENV
+          echo "PRERELEASE=true" >> $GITHUB_ENV
+          echo "DRAFT=false" >> $GITHUB_ENV
+
+      - name: Debug ref tag
+        run: echo ${{ env.REF_TAG }}
+
+      - name: Login to Docker Hub
+        uses: docker/login-action@v1
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Build static pktvisord
+        if: github.event_name != 'pull_request'
+        env:
+          IMAGE_NAME: ns1labs/pktvisord
+        run: |
+          docker build -f docker/Dockerfile.pktvisord-static -t ${{ env.IMAGE_NAME }} .
+          docker push -a ${{ env.IMAGE_NAME }}
+
+      - name: Build static pktvisor-pcap
+        if: github.event_name != 'pull_request'
+        env:
+          IMAGE_NAME: ns1labs/pktvisor-pcap
+        run: |
+          docker build -f docker/Dockerfile.pktvisor-pcap-static -t ${{ env.IMAGE_NAME }} .
+          docker push -a ${{ env.IMAGE_NAME }}
+
+      - name: Build static pktvisord-dnstap
+        if: github.event_name != 'pull_request'
+        env:
+          IMAGE_NAME: ns1labs/pktvisor-pcap
+        run: |
+          docker build -f docker/Dockerfile.pktvisor-dnstap-static -t ${{ env.IMAGE_NAME }} .
+          docker push -a ${{ env.IMAGE_NAME }}
 
 #  package:
 #    needs: build

--- a/.github/workflows/static_build.yml
+++ b/.github/workflows/static_build.yml
@@ -81,13 +81,12 @@ jobs:
 #        if: github.event_name != 'pull_request'
         env:
           BASE_BINARY: pktvisord
-          IMAGE_NAME: ns1labs/${{ env.BASE_BINARY }}-slim
-          BINARY_NAME: ${{ env.BASE_BINARY }}-linux-x86_64-${{ env.VERSION }}
+          IMAGE_NAME: ns1labs/pktvisord-slim
         run: |
           docker build -f docker/Dockerfile.${{ env.BASE_BINARY }}-static -t ${{ env.IMAGE_NAME }} .
           docker push -a ${{ env.IMAGE_NAME }}
           echo "CONT_ID=$(docker create --name ${{ env.BASE_BINARY }}-slim-tmp ${{ env.IMAGE_NAME }})" >> $GITHUB_ENV
-          docker cp ${{ env.CONT_ID }}:/${{ env.BASE_BINARY }} ${{github.workspace}}/${{ env.BINARY_NAME }}
+          docker cp ${{ env.CONT_ID }}:/${{ env.BASE_BINARY }} ${{github.workspace}}/pktvisord-linux-x86_64-${{ env.VERSION }}
 
       - name: Upload pktvisord artifact
 #        if: github.event_name != 'pull_request'

--- a/.github/workflows/static_build.yml
+++ b/.github/workflows/static_build.yml
@@ -31,7 +31,7 @@ jobs:
 
       - name: Build and test static pktvisord
         run: |
-          docker build -f docker/Dockerfile.clang-toolchain-build .
+          docker build -f docker/Dockerfile.pktvisord-static .
 
 #  package:
 #    needs: build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -81,6 +81,10 @@ if(LINUX)
         set(MUSL TRUE)
         message(STATUS "Musl libc detected")
     endif()
+    if(NOT MUSL)
+        # on gcc, use latest standard
+        set(CONAN_SETTINGS ${CONAN_SETTINGS} compiler.libcxx=libstdc++11)
+    endif()
 endif()
 
 if(MUSL)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,13 +50,17 @@ if(LINUX)
     set(CONAN_BUILD_SETTING ${CONAN_BUILD_SETTING} m4)
     foreach(SETTING ${settings})
         if (SETTING STREQUAL "compiler.libcxx=libc++")
+            set(STATIC_BINARIES TRUE)
             # if std c++ lib is libc++ (llvm) + linux then assume no gcc is available
             # (is there a way to check we're using musl?)
             # in this case must manually link libexecinfo
-            set(MUSL TRUE)
             execute_process(COMMAND ${CONAN_CMD} profile update env.pcapplusplus:LDFLAGS=-lexecinfo default)
         endif()
     endforeach()
+endif()
+
+if(STATIC_BINARIES)
+set(STATIC_FLAGS -static -lc++ -lc++abi)
 endif()
 
 conan_cmake_install(PATH_OR_REFERENCE ${CMAKE_SOURCE_DIR}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -86,6 +86,12 @@ if(LINUX)
         set(CONAN_SETTINGS ${CONAN_SETTINGS} compiler.libcxx=libstdc++11)
     endif()
 endif()
+if(APPLE)
+    # 1/3/21 clang 13.0 doesn't have a lot of binary packages yet, use 12.0 which seems compatible
+    # otherwise it has to build all packages, killing CI. remove this when binary packages show up.
+    set(CONAN_SETTINGS ${CONAN_SETTINGS} compiler.version=12.0)
+    set(CONAN_DISABLE_CHECK_COMPILER TRUE)
+endif()
 
 if(MUSL)
     # m4 inappropriately tries to use a GCC binary version, must force build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -86,12 +86,6 @@ if(LINUX)
         set(CONAN_SETTINGS ${CONAN_SETTINGS} compiler.libcxx=libstdc++11)
     endif()
 endif()
-if(APPLE)
-    # 1/3/21 clang 13.0 doesn't have a lot of binary packages yet, use 12.0 which seems compatible
-    # otherwise it has to build all packages, killing CI. remove this when binary packages show up.
-    set(CONAN_SETTINGS ${CONAN_SETTINGS} compiler.version=12.0)
-    set(CONAN_DISABLE_CHECK_COMPILER TRUE)
-endif()
 
 if(MUSL)
     # m4 inappropriately tries to use a GCC binary version, must force build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -24,8 +24,10 @@ if(VISOR_PRERELEASE STREQUAL "-develop" OR VISOR_PRERELEASE STREQUAL "-rc")
             RESULT_VARIABLE
             SHORT_HASH_RESULT
             OUTPUT_VARIABLE
-            SHORT_HASH)
-    string(REGEX REPLACE "\n$" "" SHORT_HASH "${SHORT_HASH}")
+            SHORT_HASH
+            ERROR_QUIET
+            OUTPUT_STRIP_TRAILING_WHITESPACE
+    )
     string(APPEND VISOR_PRERELEASE "-${SHORT_HASH}")
 endif()
 
@@ -55,12 +57,16 @@ conan_add_remote(NAME ns1labs INDEX 1
         URL https://ns1labs.jfrog.io/artifactory/api/conan/ns1labs-conan
         VERIFY_SSL True)
 
-conan_cmake_autodetect(settings)
+conan_cmake_autodetect(CONAN_SETTINGS)
+message(STATUS "Detected conan settings: ${CONAN_SETTINGS}")
 
+# is this destructive for developer environment?
+message(STATUS "Setting conan general.revisions_enabled=1")
 execute_process(COMMAND ${CONAN_CMD} config set general.revisions_enabled=1)
 
 # by default, build all conan dependencies that don't have a binary for this env
 set(CONAN_BUILD_SETTING missing)
+set(CONAN_ENV_SETTING "")
 
 # Linux/clang/libc++/musl special requirements
 if(UNIX AND NOT APPLE)
@@ -69,13 +75,14 @@ endif()
 if(LINUX)
     # as of 1/1/2022 m4 inappropriately tries to use a GCC binary version, must force build
     set(CONAN_BUILD_SETTING ${CONAN_BUILD_SETTING} m4)
-    foreach(SETTING ${settings})
+    # TODO check for musl like this: ldd /bin/ls | grep 'musl' | head -1 | cut -d ' ' -f1
+    foreach(SETTING ${CONAN_SETTINGS})
         if (SETTING STREQUAL "compiler.libcxx=libc++")
+            message(STATUS "Enabling musl static build")
             set(STATIC_BINARIES TRUE)
             # if std c++ lib is libc++ (llvm) + linux then assume no gcc is available
-            # (stackoverflow says to check like this: ldd /bin/ls | grep 'musl' | head -1 | cut -d ' ' -f1)
             # in this case must manually link libexecinfo
-            execute_process(COMMAND ${CONAN_CMD} profile update env.pcapplusplus:LDFLAGS=-lexecinfo default)
+            set(CONAN_ENV_SETTING ${CONAN_ENV_SETTING} pcapplusplus:LDFLAGS=-lexecinfo)
         endif()
     endforeach()
 endif()
@@ -87,7 +94,8 @@ endif()
 conan_cmake_install(PATH_OR_REFERENCE ${CMAKE_SOURCE_DIR}
         BUILD ${CONAN_BUILD_SETTING}
         GENERATOR cmake
-        SETTINGS ${settings}
+        SETTINGS ${CONAN_SETTINGS}
+        ENV ${CONAN_ENV_SETTING}
         INSTALL_FOLDER ${CMAKE_BINARY_DIR})
 
 include(${CMAKE_BINARY_DIR}/conanbuildinfo.cmake)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -21,13 +21,16 @@ if(VISOR_PRERELEASE STREQUAL "-develop" OR VISOR_PRERELEASE STREQUAL "-rc")
     execute_process(
             COMMAND
             git rev-parse --short HEAD
+            WORKING_DIRECTORY ${CMAKE_SOURCE_DIR}
             RESULT_VARIABLE
             SHORT_HASH_RESULT
             OUTPUT_VARIABLE
             SHORT_HASH
-            ERROR_QUIET
             OUTPUT_STRIP_TRAILING_WHITESPACE
     )
+    if (${SHORT_HASH} STREQUAL "")
+        message(FATAL "Unable to get current git hash for develop/rc version")
+    endif ()
     string(APPEND VISOR_PRERELEASE "-${SHORT_HASH}")
 endif()
 
@@ -118,7 +121,7 @@ set(VISOR_STATIC_PLUGINS)
 
 enable_testing()
 
-message(STATUS "Building pktvisor version ${CMAKE_PROJECT_VERSION_MAJOR}.${CMAKE_PROJECT_VERSION_MINOR}.${CMAKE_PROJECT_VERSION_MINOR}${VISOR_PRERELEASE}")
+message(STATUS "Building pktvisor version ${CMAKE_PROJECT_VERSION_MAJOR}.${CMAKE_PROJECT_VERSION_MINOR}.${CMAKE_PROJECT_VERSION_PATCH}${VISOR_PRERELEASE}")
 add_subdirectory(3rd)
 add_subdirectory(src)
 add_subdirectory(cmd)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -67,28 +67,34 @@ execute_process(COMMAND ${CONAN_CMD} config set general.revisions_enabled=1)
 # by default, build all conan dependencies that don't have a binary for this env
 set(CONAN_BUILD_SETTING missing)
 set(CONAN_ENV_SETTING "")
+set(DYNAMIC_LIB_SUPPORT TRUE)
 
-# Linux/clang/libc++/musl special requirements
 if(UNIX AND NOT APPLE)
     set(LINUX TRUE)
 endif()
 if(LINUX)
-    # as of 1/1/2022 m4 inappropriately tries to use a GCC binary version, must force build
+    execute_process(
+            COMMAND ldd /bin/ls
+            OUTPUT_VARIABLE MUSL_CHECK
+    )
+    if(MUSL_CHECK MATCHES "musl")
+        set(MUSL TRUE)
+        message(STATUS "Musl libc detected")
+    endif()
+endif()
+
+if(MUSL)
+    # m4 inappropriately tries to use a GCC binary version, must force build
     set(CONAN_BUILD_SETTING ${CONAN_BUILD_SETTING} m4)
-    # TODO check for musl like this: ldd /bin/ls | grep 'musl' | head -1 | cut -d ' ' -f1
-    foreach(SETTING ${CONAN_SETTINGS})
-        if (SETTING STREQUAL "compiler.libcxx=libc++")
-            message(STATUS "Enabling musl static build")
-            set(STATIC_BINARIES TRUE)
-            # if std c++ lib is libc++ (llvm) + linux then assume no gcc is available
-            # in this case must manually link libexecinfo
-            set(CONAN_ENV_SETTING ${CONAN_ENV_SETTING} pcapplusplus:LDFLAGS=-lexecinfo)
-        endif()
-    endforeach()
+    # pcapplusplus uses a gcc extension for backtrace, musl needs an extra lib to emulate
+    set(CONAN_ENV_SETTING ${CONAN_ENV_SETTING} pcapplusplus:LDFLAGS=-lexecinfo)
+    set(STATIC_BINARIES TRUE)
+    set(DYNAMIC_LIB_SUPPORT FALSE)
 endif()
 
 if(STATIC_BINARIES)
-set(STATIC_FLAGS -static -lc++ -lc++abi)
+    message(STATUS "Enabling statically linked binaries")
+    set(STATIC_FLAGS -static -lc++ -lc++abi)
 endif()
 
 conan_cmake_install(PATH_OR_REFERENCE ${CMAKE_SOURCE_DIR}

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,9 +35,31 @@ conan_add_remote(NAME ns1labs INDEX 1
         VERIFY_SSL True)
 
 conan_cmake_autodetect(settings)
+
 execute_process(COMMAND ${CONAN_CMD} config set general.revisions_enabled=1)
+
+# by default, build all conan dependencies that don't have a binary for this env
+set(CONAN_BUILD_SETTING missing)
+
+# Linux/clang/libc++/musl special requirements
+if(UNIX AND NOT APPLE)
+    set(LINUX TRUE)
+endif()
+if(LINUX)
+    # as of 1/1/2022 m4 inappropriately tries to use a GCC binary version, must force build
+    set(CONAN_BUILD_SETTING ${CONAN_BUILD_SETTING} m4)
+    foreach(SETTING ${settings})
+        if (SETTING STREQUAL "compiler.libcxx=libc++")
+            # if std c++ lib is libc++ (llvm) + linux then assume no gcc is available
+            # (is there a way to check we're using musl?)
+            # in this case must manually link libexecinfo
+            execute_process(COMMAND ${CONAN_CMD} profile update env.pcapplusplus:LDFLAGS=-lexecinfo default)
+        endif()
+    endforeach()
+endif()
+
 conan_cmake_install(PATH_OR_REFERENCE ${CMAKE_SOURCE_DIR}
-        BUILD missing m4
+        BUILD ${CONAN_BUILD_SETTING}
         GENERATOR cmake
         SETTINGS ${settings}
         INSTALL_FOLDER ${CMAKE_BINARY_DIR})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -26,6 +26,8 @@ set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 #set(CMAKE_VERBOSE_MAKEFILE ON)
 add_compile_options(-Wall -pedantic -W -Wextra -Wno-unknown-pragmas)
 
+# use a custom conan home directory in our build directory
+set(ENV{CONAN_USER_HOME} ${CMAKE_BINARY_DIR}/conan_home)
 include(conan)
 
 conan_add_remote(NAME ns1labs INDEX 1
@@ -33,9 +35,9 @@ conan_add_remote(NAME ns1labs INDEX 1
         VERIFY_SSL True)
 
 conan_cmake_autodetect(settings)
-
+execute_process(COMMAND ${CONAN_CMD} config set general.revisions_enabled=1)
 conan_cmake_install(PATH_OR_REFERENCE ${CMAKE_SOURCE_DIR}
-        BUILD missing
+        BUILD missing m4
         GENERATOR cmake
         SETTINGS ${settings}
         INSTALL_FOLDER ${CMAKE_BINARY_DIR})

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,7 +53,7 @@ add_compile_options(-Wall -pedantic -W -Wextra -Wno-unknown-pragmas)
 set(ENV{CONAN_USER_HOME} ${CMAKE_BINARY_DIR}/conan_home)
 include(conan)
 
-conan_add_remote(NAME ns1labs INDEX 1
+conan_add_remote(NAME ns1labs INDEX 0
         URL https://ns1labs.jfrog.io/artifactory/api/conan/ns1labs-conan
         VERIFY_SSL True)
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -53,6 +53,7 @@ if(LINUX)
             # if std c++ lib is libc++ (llvm) + linux then assume no gcc is available
             # (is there a way to check we're using musl?)
             # in this case must manually link libexecinfo
+            set(MUSL TRUE)
             execute_process(COMMAND ${CONAN_CMD} profile update env.pcapplusplus:LDFLAGS=-lexecinfo default)
         endif()
     endforeach()

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,8 +1,9 @@
 cmake_minimum_required(VERSION 3.13)
 
-list(APPEND CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake")
-
+#######################################################
 # VERSION
+#######################################################
+
 # this is the source of truth for semver version
 project(visor VERSION 3.4.0)
 
@@ -10,6 +11,25 @@ project(visor VERSION 3.4.0)
 # for development release, this is "-develop"
 # for release candidate, this is "-rc"
 set(VISOR_PRERELEASE "-develop")
+
+#######################################################
+
+# if develop or rc build, add git hash
+# note this only updates on cmake reconfigure, not every git commit
+# so it's mainly useful for GitHub CI, not developers
+if(VISOR_PRERELEASE STREQUAL "-develop" OR VISOR_PRERELEASE STREQUAL "-rc")
+    execute_process(
+            COMMAND
+            git rev-parse --short HEAD
+            RESULT_VARIABLE
+            SHORT_HASH_RESULT
+            OUTPUT_VARIABLE
+            SHORT_HASH)
+    string(REGEX REPLACE "\n$" "" SHORT_HASH "${SHORT_HASH}")
+    string(APPEND VISOR_PRERELEASE "-${SHORT_HASH}")
+endif()
+
+list(APPEND CMAKE_MODULE_PATH "${CMAKE_SOURCE_DIR}/cmake")
 
 # these are computed
 set(VISOR_VERSION_NUM "${PROJECT_VERSION}${VISOR_PRERELEASE}")
@@ -27,6 +47,7 @@ set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 add_compile_options(-Wall -pedantic -W -Wextra -Wno-unknown-pragmas)
 
 # use a custom conan home directory in our build directory
+# this allows us to use the clang-toolchain docker image in CLion docker toolchain
 set(ENV{CONAN_USER_HOME} ${CMAKE_BINARY_DIR}/conan_home)
 include(conan)
 
@@ -52,7 +73,7 @@ if(LINUX)
         if (SETTING STREQUAL "compiler.libcxx=libc++")
             set(STATIC_BINARIES TRUE)
             # if std c++ lib is libc++ (llvm) + linux then assume no gcc is available
-            # (is there a way to check we're using musl?)
+            # (stackoverflow says to check like this: ldd /bin/ls | grep 'musl' | head -1 | cut -d ' ' -f1)
             # in this case must manually link libexecinfo
             execute_process(COMMAND ${CONAN_CMD} profile update env.pcapplusplus:LDFLAGS=-lexecinfo default)
         endif()
@@ -78,6 +99,8 @@ include(sanitizer)
 set(VISOR_STATIC_PLUGINS)
 
 enable_testing()
+
+message(STATUS "Building pktvisor version ${CMAKE_PROJECT_VERSION_MAJOR}.${CMAKE_PROJECT_VERSION_MINOR}.${CMAKE_PROJECT_VERSION_MINOR}${VISOR_PRERELEASE}")
 add_subdirectory(3rd)
 add_subdirectory(src)
 add_subdirectory(cmd)

--- a/cmd/pktvisor-dnstap/CMakeLists.txt
+++ b/cmd/pktvisor-dnstap/CMakeLists.txt
@@ -9,4 +9,5 @@ target_link_libraries(pktvisor-dnstap
         PRIVATE
         ${CONAN_LIBS_DOCOPT.CPP}
         ${VISOR_STATIC_PLUGINS}
+        ${STATIC_FLAGS}
         )

--- a/cmd/pktvisor-pcap/CMakeLists.txt
+++ b/cmd/pktvisor-pcap/CMakeLists.txt
@@ -9,4 +9,5 @@ target_link_libraries(pktvisor-pcap
         PRIVATE
         ${CONAN_LIBS_DOCOPT.CPP}
         ${VISOR_STATIC_PLUGINS}
+        ${STATIC_FLAGS}
         )

--- a/cmd/pktvisord/CMakeLists.txt
+++ b/cmd/pktvisord/CMakeLists.txt
@@ -5,10 +5,6 @@ target_include_directories(pktvisord
         ${CMAKE_BINARY_DIR}/src # Visor::Core config.h
         )
 
-if (MUSL)
-    set(PKTVISORD_STATIC -static -lc++ -lc++abi)
-endif()
-
 target_link_libraries(pktvisord
         PRIVATE
         timer
@@ -16,5 +12,5 @@ target_link_libraries(pktvisord
         ${CONAN_LIBS_DOCOPT.CPP}
         Visor::Core
         ${VISOR_STATIC_PLUGINS}
-        ${PKTVISORD_STATIC}
+        ${STATIC_FLAGS}
         )

--- a/cmd/pktvisord/CMakeLists.txt
+++ b/cmd/pktvisord/CMakeLists.txt
@@ -5,6 +5,10 @@ target_include_directories(pktvisord
         ${CMAKE_BINARY_DIR}/src # Visor::Core config.h
         )
 
+if (MUSL)
+    set(PKTVISORD_STATIC -static -lc++ -lc++abi)
+endif()
+
 target_link_libraries(pktvisord
         PRIVATE
         timer
@@ -12,4 +16,5 @@ target_link_libraries(pktvisord
         ${CONAN_LIBS_DOCOPT.CPP}
         Visor::Core
         ${VISOR_STATIC_PLUGINS}
+        ${PKTVISORD_STATIC}
         )

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -8,6 +8,8 @@ RUN \
     apt-get install --yes --force-yes --no-install-recommends ${BUILD_DEPS} && \
     pip3 install conan
 
+# need git for current hash for VERSION
+COPY ./.git/ /pktvisor-src/.git/
 COPY ./src/ /pktvisor-src/src/
 COPY ./cmd/ /pktvisor-src/cmd/
 COPY ./3rd/ /pktvisor-src/3rd/

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -8,7 +8,14 @@ RUN \
     apt-get install --yes --force-yes --no-install-recommends ${BUILD_DEPS} && \
     pip3 install conan
 
-COPY . /pktvisor-src/
+COPY ./src/ /pktvisor-src/src/
+COPY ./cmd/ /pktvisor-src/cmd/
+COPY ./3rd/ /pktvisor-src/3rd/
+COPY ./golang/ /pktvisor-src/golang/
+COPY ./integration_tests/ /pktvisor-src/integration_tests/
+COPY ./cmake/ /pktvisor-src/cmake/
+COPY ./CMakeLists.txt /pktvisor-src/
+COPY ./conanfile.txt /pktvisor-src/
 
 WORKDIR /tmp/build
 RUN \

--- a/docker/Dockerfile.clang-toolchain
+++ b/docker/Dockerfile.clang-toolchain
@@ -11,9 +11,6 @@ RUN ln -s /usr/local/bin/clang /usr/local/bin/cc \
     && ln -s /usr/local/bin/clang++ /usr/local/bin/c++ \
     && ln -s /usr/local/bin/clang++ /usr/local/bin/g++ \
     && ln -s /usr/local/bin/clang-cpp /usr/local/bin/cpp \
-    && pip install conan \
-    && conan profile new default --detect \
-    && conan profile update settings.compiler.libcxx=libc++ default \
-    && conan config set general.revisions_enabled=1
+    && pip install conan
 
 USER builder

--- a/docker/Dockerfile.clang-toolchain
+++ b/docker/Dockerfile.clang-toolchain
@@ -1,0 +1,19 @@
+FROM genshen/clang-toolchain:12.0.0
+ARG REQUIRE="make cmake python3 py3-pip perl git bash libexecinfo-static libexecinfo-dev"
+ARG UID=1000
+
+RUN adduser -u ${UID} -D builder
+
+RUN apk add --no-cache ${REQUIRE}
+
+RUN ln -s /usr/local/bin/clang /usr/local/bin/cc \
+    && ln -s /usr/local/bin/clang /usr/local/bin/gcc \
+    && ln -s /usr/local/bin/clang++ /usr/local/bin/c++ \
+    && ln -s /usr/local/bin/clang++ /usr/local/bin/g++ \
+    && ln -s /usr/local/bin/clang-cpp /usr/local/bin/cpp \
+    && pip install conan \
+    && conan profile new default --detect \
+    && conan profile update settings.compiler.libcxx=libc++ default \
+    && conan config set general.revisions_enabled=1
+
+USER builder

--- a/docker/Dockerfile.clang-toolchain
+++ b/docker/Dockerfile.clang-toolchain
@@ -1,4 +1,4 @@
-FROM genshen/clang-toolchain:12.0.0
+FROM ns1labs/clang-toolchain:latest
 ARG REQUIRE="make cmake python3 py3-pip perl git bash libexecinfo-static libexecinfo-dev"
 ARG UID=1000
 

--- a/docker/Dockerfile.clang-toolchain-build
+++ b/docker/Dockerfile.clang-toolchain-build
@@ -14,9 +14,6 @@ RUN ln -s /usr/local/bin/clang /usr/local/bin/cc \
 COPY . /pktvisor-src/
 
 WORKDIR /tmp/build
-RUN \
-    conan profile new --detect default && \
-    conan config set general.revisions_enabled=1
 
 RUN \
     PKG_CONFIG_PATH=/local/lib/pkgconfig cmake -DCMAKE_BUILD_TYPE=Release /pktvisor-src && \

--- a/docker/Dockerfile.clang-toolchain-build
+++ b/docker/Dockerfile.clang-toolchain-build
@@ -11,10 +11,15 @@ RUN ln -s /usr/local/bin/clang /usr/local/bin/cc \
     && pip install conan \
     && conan profile new --detect default
 
+COPY . /pktvisor-src/
+
+WORKDIR /tmp/build
 RUN \
-    mkdir build && \
-    cd build && \
-    cmake -DCMAKE_BUILD_TYPE=Release .. && \
+    conan profile new --detect default && \
+    conan config set general.revisions_enabled=1
+
+RUN \
+    PKG_CONFIG_PATH=/local/lib/pkgconfig cmake -DCMAKE_BUILD_TYPE=Release /pktvisor-src && \
     make all test -j 4
 
 FROM alpine:latest AS runtime

--- a/docker/Dockerfile.clang-toolchain-build
+++ b/docker/Dockerfile.clang-toolchain-build
@@ -1,0 +1,24 @@
+FROM ns1labs/clang-toolchain:latest AS cppbuild
+ARG REQUIRE="make cmake python3 py3-pip perl git bash libexecinfo-static libexecinfo-dev"
+
+RUN apk add --no-cache ${REQUIRE}
+
+RUN ln -s /usr/local/bin/clang /usr/local/bin/cc \
+    && ln -s /usr/local/bin/clang /usr/local/bin/gcc \
+    && ln -s /usr/local/bin/clang++ /usr/local/bin/c++ \
+    && ln -s /usr/local/bin/clang++ /usr/local/bin/g++ \
+    && ln -s /usr/local/bin/clang-cpp /usr/local/bin/cpp \
+    && pip install conan \
+    && conan profile new --detect default
+
+RUN \
+    mkdir build && \
+    cd build && \
+    cmake -DCMAKE_BUILD_TYPE=Release .. && \
+    make all test -j 4
+
+FROM alpine:latest AS runtime
+
+COPY --from=cppbuild /build/bin/pktvisord /pktvisord
+
+ENTRYPOINT [ "/pktvisord" ]

--- a/docker/Dockerfile.pktvisor-dnstap-static
+++ b/docker/Dockerfile.pktvisor-dnstap-static
@@ -1,0 +1,7 @@
+FROM ns1labs/static-base AS cppbuild
+
+FROM scratch AS runtime
+
+COPY --from=cppbuild /tmp/build/bin/pktvisor-dnstap /pktvisor-dnstap
+
+ENTRYPOINT [ "/pktvisor-dnstap" ]

--- a/docker/Dockerfile.pktvisor-pcap-static
+++ b/docker/Dockerfile.pktvisor-pcap-static
@@ -1,0 +1,7 @@
+FROM ns1labs/static-base AS cppbuild
+
+FROM scratch AS runtime
+
+COPY --from=cppbuild /tmp/build/bin/pktvisor-pcap /pktvisor-pcap
+
+ENTRYPOINT [ "/pktvisor-pcap" ]

--- a/docker/Dockerfile.pktvisord-static
+++ b/docker/Dockerfile.pktvisord-static
@@ -8,18 +8,16 @@ RUN ln -s /usr/local/bin/clang /usr/local/bin/cc \
     && ln -s /usr/local/bin/clang++ /usr/local/bin/c++ \
     && ln -s /usr/local/bin/clang++ /usr/local/bin/g++ \
     && ln -s /usr/local/bin/clang-cpp /usr/local/bin/cpp \
-    && pip install conan \
-    && conan profile new --detect default
+    && pip install conan
 
 COPY . /pktvisor-src/
 
 WORKDIR /tmp/build
 
-RUN \
-    PKG_CONFIG_PATH=/local/lib/pkgconfig cmake -DCMAKE_BUILD_TYPE=Release /pktvisor-src && \
-    make all test -j 4
+RUN cmake -DCMAKE_BUILD_TYPE=Release /pktvisor-src \
+    && make all test -j 4
 
-FROM alpine:latest AS runtime
+FROM scratch AS runtime
 
 COPY --from=cppbuild /build/bin/pktvisord /pktvisord
 

--- a/docker/Dockerfile.pktvisord-static
+++ b/docker/Dockerfile.pktvisord-static
@@ -1,24 +1,7 @@
-FROM ns1labs/clang-toolchain:latest AS cppbuild
-ARG REQUIRE="make cmake python3 py3-pip perl git bash libexecinfo-static libexecinfo-dev"
-
-RUN apk add --no-cache ${REQUIRE}
-
-RUN ln -s /usr/local/bin/clang /usr/local/bin/cc \
-    && ln -s /usr/local/bin/clang /usr/local/bin/gcc \
-    && ln -s /usr/local/bin/clang++ /usr/local/bin/c++ \
-    && ln -s /usr/local/bin/clang++ /usr/local/bin/g++ \
-    && ln -s /usr/local/bin/clang-cpp /usr/local/bin/cpp \
-    && pip install conan
-
-COPY . /pktvisor-src/
-
-WORKDIR /tmp/build
-
-RUN cmake -DCMAKE_BUILD_TYPE=Release /pktvisor-src \
-    && make all test -j 4
+FROM ns1labs/static-base AS cppbuild
 
 FROM scratch AS runtime
 
-COPY --from=cppbuild /build/bin/pktvisord /pktvisord
+COPY --from=cppbuild /tmp/build/bin/pktvisord /pktvisord
 
 ENTRYPOINT [ "/pktvisord" ]

--- a/docker/Dockerfile.static-base
+++ b/docker/Dockerfile.static-base
@@ -1,0 +1,25 @@
+FROM ns1labs/clang-toolchain:latest AS cppbuild
+ARG REQUIRE="make cmake python3 py3-pip perl git bash libexecinfo-static libexecinfo-dev"
+
+RUN apk add --no-cache ${REQUIRE}
+
+RUN ln -s /usr/local/bin/clang /usr/local/bin/cc \
+    && ln -s /usr/local/bin/clang /usr/local/bin/gcc \
+    && ln -s /usr/local/bin/clang++ /usr/local/bin/c++ \
+    && ln -s /usr/local/bin/clang++ /usr/local/bin/g++ \
+    && ln -s /usr/local/bin/clang-cpp /usr/local/bin/cpp \
+    && pip install conan
+
+COPY ./src/ /pktvisor-src/src/
+COPY ./cmd/ /pktvisor-src/cmd/
+COPY ./3rd/ /pktvisor-src/3rd/
+COPY ./golang/ /pktvisor-src/golang/
+COPY ./integration_tests/ /pktvisor-src/integration_tests/
+COPY ./cmake/ /pktvisor-src/cmake/
+COPY ./CMakeLists.txt /pktvisor-src/
+COPY ./conanfile.txt /pktvisor-src/
+
+WORKDIR /tmp/build
+
+RUN cmake -DCMAKE_BUILD_TYPE=Release /pktvisor-src \
+    && make all test -j 4

--- a/docker/Dockerfile.static-base
+++ b/docker/Dockerfile.static-base
@@ -25,3 +25,7 @@ WORKDIR /tmp/build
 
 RUN cmake -DCMAKE_BUILD_TYPE=Release /pktvisor-src \
     && make all test -j 4
+
+# after build, use this to upload conan packages to ns1labs jfrog server
+# docker run --rm -it ns1labs/static-base
+# CONAN_USER_HOME=/tmp/build/conan_home conan upload "*" --all -r ns1labs -c

--- a/docker/Dockerfile.static-base
+++ b/docker/Dockerfile.static-base
@@ -10,6 +10,8 @@ RUN ln -s /usr/local/bin/clang /usr/local/bin/cc \
     && ln -s /usr/local/bin/clang-cpp /usr/local/bin/cpp \
     && pip install conan
 
+# need git for current hash for VERSION
+COPY ./.git/ /pktvisor-src/.git/
 COPY ./src/ /pktvisor-src/src/
 COPY ./cmd/ /pktvisor-src/cmd/
 COPY ./3rd/ /pktvisor-src/3rd/

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -1,0 +1,5 @@
+
+.PHONY: clang-toolchain
+
+clang-toolchain:
+	docker build --build-arg UID=$(shell id -u) -t pktvisor/clang-toolchain -f Dockerfile.clang-toolchain .

--- a/docker/Makefile
+++ b/docker/Makefile
@@ -1,5 +1,7 @@
 
 .PHONY: clang-toolchain
 
+# for developer environments (e.g. clion docker toolchain)
+# note does not require/include the source base
 clang-toolchain:
 	docker build --build-arg UID=$(shell id -u) -t pktvisor/clang-toolchain -f Dockerfile.clang-toolchain .

--- a/integration_tests/CMakeLists.txt
+++ b/integration_tests/CMakeLists.txt
@@ -25,7 +25,9 @@ visor_pcap_int_test(dns_ipv6_udp)
 visor_pcap_int_test(dns_ipv6_tcp)
 visor_pcap_int_test(dhcp-flow)
 
-visor_dyn_mod_int_test(VisorHandlerMock)
+if(DYNAMIC_LIB_SUPPORT)
+    visor_dyn_mod_int_test(VisorHandlerMock)
+endif()
 
 # this allows local, non-public integration tests (for example, on private pcap data)
 #add_test(NAME external-tests

--- a/src/AbstractMetricsManager.h
+++ b/src/AbstractMetricsManager.h
@@ -54,7 +54,7 @@ private:
 
     timespec _start_tstamp;
     timespec _end_tstamp;
-    uint _period_length = 0;
+    unsigned int _period_length = 0;
     bool _read_only = false;
     bool _recorded_stream = false;
 
@@ -91,7 +91,7 @@ public:
         return _end_tstamp;
     }
 
-    uint period_length() const
+    unsigned int period_length() const
     {
         std::shared_lock r_lock(_base_mutex);
         if (_read_only || _recorded_stream) {
@@ -214,7 +214,7 @@ private:
     /**
      * the total number of periods we will maintain in the window
      */
-    uint _num_periods{5};
+    unsigned int _num_periods{5};
 
     /**
      * sampling
@@ -242,7 +242,7 @@ private:
     /**
      * simple cache for json results
      */
-    mutable std::unordered_map<uint, std::pair<std::chrono::high_resolution_clock::time_point, json>> _mergeResultCache;
+    mutable std::unordered_map<unsigned int, std::pair<std::chrono::high_resolution_clock::time_point, json>> _mergeResultCache;
 
     /**
      * manage the time window
@@ -278,8 +278,8 @@ private:
     }
 
 public:
-    static const uint PERIOD_SEC = 60;
-    static const uint MERGE_CACHE_TTL_MS = 1000;
+    static const unsigned int PERIOD_SEC = 60;
+    static const unsigned int MERGE_CACHE_TTL_MS = 1000;
 
 protected:
     /**
@@ -360,7 +360,7 @@ public:
         });
     }
 
-    uint num_periods() const
+    unsigned int num_periods() const
     {
         std::shared_lock rl(_base_mutex);
         return _num_periods;
@@ -372,7 +372,7 @@ public:
         return _metric_buckets.size();
     }
 
-    uint deep_sample_rate() const
+    unsigned int deep_sample_rate() const
     {
         std::shared_lock rl(_base_mutex);
         return _deep_sample_rate;

--- a/src/handlers/dns/DnsStreamHandler.cpp
+++ b/src/handlers/dns/DnsStreamHandler.cpp
@@ -202,7 +202,7 @@ void DnsStreamHandler::tcp_message_ready_cb(int8_t side, const pcpp::TcpStreamDa
     auto port{iter->second.port};
     timespec stamp{0, 0};
     // for tcp, endTime is updated by pcpp to represent the time stamp from the latest packet in the stream
-    TIMEVAL_TO_TIMESPEC(&tcpData.getConnectionData().endTime, &stamp)
+    TIMEVAL_TO_TIMESPEC(&tcpData.getConnectionData().endTime, &stamp);
     auto dir = (side == 0) ? PacketDirection::fromHost : PacketDirection::toHost;
 
     auto got_dns_message = [this, port, dir, l3Type, flowKey, stamp](std::unique_ptr<uint8_t[]> data, size_t size) {

--- a/src/tests/test_metrics.cpp
+++ b/src/tests/test_metrics.cpp
@@ -252,7 +252,7 @@ TEST_CASE("Cardinality metrics", "[metrics][cardinality]")
         c.update("metric");
         c.to_json(j);
         CHECK(j["test"]["metric"] == 1);
-        u_int8_t data[16] = {2, 0, 0, 1, ':', 'd', 'b', 8, ':', 3, 'c', 4, 'd', ':', 1, 5};
+        uint8_t data[16] = {2, 0, 0, 1, ':', 'd', 'b', 8, ':', 3, 'c', 4, 'd', ':', 1, 5};
         c.update(reinterpret_cast<const void *>(data), 16);
         c.to_json(j["top"]);
         CHECK(j["top"]["test"]["metric"] == 2);


### PR DESCRIPTION
Introduce a new docker based build which runs on a clang/libc++/musl only toolchain (no gcc). This enables us to build statically linked executables for linux.

Introduce docker/Dockerfile.clang-toolchain which can be used in CLion Docker Toolchains.

Includes some code changes to necessary to compile under under this stack.

Build static binaries, pushed `-slim` docker containers, and create GitHub assets.
