### PR TITLE
user permission and single handler

### DIFF
--- a/automated_tests/docs/development_guide.md
+++ b/automated_tests/docs/development_guide.md
@@ -2,18 +2,18 @@
 ## **PKTVISOR**
 
 
-|                                                                                          Scenario                                                                                          | Automated | Smoke | Sanity | 
-|:------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------:|:---------:|:-----:|:------:|
-|                                            [Run pktvisor instance using docker command](pktvisor/run_pktvisor_instance_using_docker_command.md)                                            |    👍     |  👍   |   👍   |   
-|                                [Run multiple pktvisors instances using different ports](pktvisor/run_multiple_pktvisors_instances_using_different_ports.md)                                |    👍     |  👍   |   👍   |
-|                                 [Run multiple pktvisors instances using the same ports](pktvisor/run_multiple_pktvisors_instances_using_the_same_ports.md)                                 |    👍     |  👍   |   👍   |
- |                              [Create a policy using admin permission with all handlers](pktvisor/create_a_policy_using_admin_permission_with_all_handlers.md)                              |    👍     |  👍   |   👍   |
- |                          [Create a policy using admin permission with only dns handler](pktvisor/create_a_policy_using_admin_permission_with_only_one_handler.md)                          |           |       |        |
-|                          [Create a policy using admin permission with only net handler](pktvisor/create_a_policy_using_admin_permission_with_only_one_handler.md)                          |           |       |        |
-|                         [Create a policy using admin permission with only dhcp handler](pktvisor/create_a_policy_using_admin_permission_with_only_one_handler.md)                          |           |       |        |
-|                         [Create a policy using admin permission with only pcap handler](pktvisor/create_a_policy_using_admin_permission_with_only_one_handler.md)                          |           |       |        |
-|                       [Remove all policies using admin permission from pktvisor instance](pktvisor/remove_policies_using_admin_permission_from_pktvisor_instance.md)                       |    👍     |  👍   |   👍   |
-|                        [Remove one policy using admin permission from pktvisor instance](pktvisor/remove_policies_using_admin_permission_from_pktvisor_instance.md)                        |    👍     |  👍   |   👍   |
- |                                              [Create a policy without admin permission](pktvisor/create_a_policy_without_admin_permission.md)                                              |           |       |        |
-|                                              [Remove a policy without admin permission](pktvisor/remove_a_policy_without_admin_permission.md)                                              |           |       |        |
-|                                                            [Disable pktvisor's metrics](pktvisor/disable_pktvisor's_metrics.md)                                                            |           |       |        |
+|                                                                    Scenario                                                                    | Automated | Smoke | Sanity | 
+|:----------------------------------------------------------------------------------------------------------------------------------------------:|:---------:|:-----:|:------:|
+|                      [Run pktvisor instance using docker command](pktvisor/run_pktvisor_instance_using_docker_command.md)                      |    👍     |  👍   |   👍   |   
+|          [Run multiple pktvisors instances using different ports](pktvisor/run_multiple_pktvisors_instances_using_different_ports.md)          |    👍     |  👍   |   👍   |
+|           [Run multiple pktvisors instances using the same ports](pktvisor/run_multiple_pktvisors_instances_using_the_same_ports.md)           |    👍     |  👍   |   👍   |
+ |        [Create a policy using admin permission with all handlers](pktvisor/create_a_policy_using_admin_permission_with_all_handlers.md)        |    👍     |  👍   |   👍   |
+ |    [Create a policy using admin permission with only dns handler](pktvisor/create_a_policy_using_admin_permission_with_only_one_handler.md)    |    👍     |  👍   |   👍   |
+|    [Create a policy using admin permission with only net handler](pktvisor/create_a_policy_using_admin_permission_with_only_one_handler.md)    |    👍     |  👍   |   👍   |
+|   [Create a policy using admin permission with only dhcp handler](pktvisor/create_a_policy_using_admin_permission_with_only_one_handler.md)    |    👍     |  👍   |   👍   |
+|   [Create a policy using admin permission with only pcap handler](pktvisor/create_a_policy_using_admin_permission_with_only_one_handler.md)    |    👍     |  👍   |   👍   |
+| [Remove all policies using admin permission from pktvisor instance](pktvisor/remove_policies_using_admin_permission_from_pktvisor_instance.md) |    👍     |  👍   |   👍   |
+|  [Remove one policy using admin permission from pktvisor instance](pktvisor/remove_policies_using_admin_permission_from_pktvisor_instance.md)  |    👍     |  👍   |   👍   |
+ |                        [Create a policy without admin permission](pktvisor/create_a_policy_without_admin_permission.md)                        |    👍     |  👍   |   👍   |
+|                        [Remove a policy without admin permission](pktvisor/remove_a_policy_without_admin_permission.md)                        |    👍     |  👍   |   👍   |
+|                                      [Disable pktvisor's metrics](pktvisor/disable_pktvisor's_metrics.md)                                      |           |       |        |

--- a/automated_tests/features/pktvisor.feature
+++ b/automated_tests/features/pktvisor.feature
@@ -19,18 +19,52 @@ Scenario: run multiple pktvisors instances using the same port
   Then 1 pktvisor's containers must be running
     And 1 pktvisor's containers must be exited
 
-Scenario: create a policy
+
+Scenario: create a policy with all handlers using admin permission
   Given that a pktvisor instance is running on port default with admin permission
-  When create a new policy
+  When create a new policy with all handler(s)
   Then 2 policies must be running
 
-Scenario: delete all policies
+Scenario: create a policy with net handler using admin permission
+  Given that a pktvisor instance is running on port default with admin permission
+  When create a new policy with net handler(s)
+  Then 2 policies must be running
+
+Scenario: create a policy with dhcp handler using admin permission
+  Given that a pktvisor instance is running on port default with admin permission
+  When create a new policy with dhcp handler(s)
+  Then 2 policies must be running
+
+Scenario: create a policy with dns handler using admin permission
+  Given that a pktvisor instance is running on port default with admin permission
+  When create a new policy with dns handler(s)
+  Then 2 policies must be running
+
+Scenario: create a policy with pcap stats handler using admin permission
+  Given that a pktvisor instance is running on port default with admin permission
+  When create a new policy with pcap_stats handler(s)
+  Then 2 policies must be running
+
+Scenario: delete all policies using admin permission
   Given that a pktvisor instance is running on port default with admin permission
   When delete 1 policies
   Then 0 policies must be running
 
-Scenario: delete 1 policy
+Scenario: delete 1 policy using admin permission
   Given that a pktvisor instance is running on port default with admin permission
-  When create a new policy
+  When create a new policy with all handler(s)
     And delete 1 policies
   Then 1 policies must be running
+
+Scenario: create a policy using user permission
+  Given that a pktvisor instance is running on port 10854 with user permission
+  When try to create a new policy with all handler(s)
+  Then status code returned on response must be 404
+    And 1 policies must be running
+
+
+Scenario: delete 1 policy using user permission
+  Given that a pktvisor instance is running on port default with user permission
+  When try to delete a policy
+  Then status code returned on response must be 404
+    And 1 policies must be running

--- a/automated_tests/features/steps/policies.py
+++ b/automated_tests/features/steps/policies.py
@@ -1,3 +1,5 @@
+from hamcrest import *
+
 class policies:
     def __init__(self):
         pass
@@ -29,3 +31,106 @@ class policies:
                           type: pcap
             """
         return policy_yaml
+
+    @classmethod
+    def generate_pcap_policy_with_only_net_handler(cls, name):
+        policy_yaml = f"""
+            version: "1.0"
+        
+            visor:
+              policies:
+               {name}:
+                 kind: collection
+                 input:
+                   tap: default
+                   input_type: pcap
+                 handlers:
+                    window_config:
+                      num_periods: 5
+                      deep_sample_rate: 100
+                    modules:
+                        net:
+                          type: net
+            """
+        return policy_yaml
+
+    @classmethod
+    def generate_pcap_policy_with_only_dhcp_handler(cls, name):
+        policy_yaml = f"""
+            version: "1.0"
+        
+            visor:
+              policies:
+               {name}:
+                 kind: collection
+                 input:
+                   tap: default
+                   input_type: pcap
+                 handlers:
+                    window_config:
+                      num_periods: 5
+                      deep_sample_rate: 100
+                    modules:
+                        dhcp:
+                          type: dhcp
+            """
+        return policy_yaml
+    
+    @classmethod
+    def generate_pcap_policy_with_only_dns_handler(cls, name):
+        policy_yaml = f"""
+            version: "1.0"
+        
+            visor:
+              policies:
+               {name}:
+                 kind: collection
+                 input:
+                   tap: default
+                   input_type: pcap
+                 handlers:
+                    window_config:
+                      num_periods: 5
+                      deep_sample_rate: 100
+                    modules:
+                        dns:
+                          type: dns
+            """
+        return policy_yaml
+    
+    @classmethod
+    def generate_pcap_policy_with_only_pcap_stats_handler(cls, name):
+        policy_yaml = f"""
+            version: "1.0"
+        
+            visor:
+              policies:
+               {name}:
+                 kind: collection
+                 input:
+                   tap: default
+                   input_type: pcap
+                 handlers:
+                    window_config:
+                      num_periods: 5
+                      deep_sample_rate: 100
+                    modules:
+                        pcap_stats:
+                          type: pcap
+            """
+        return policy_yaml
+
+    @classmethod
+    def generate_policy(cls, handler, name):
+        assert_that(handler, any_of(equal_to("all"), equal_to("net"), equal_to("dhcp"),
+                                    equal_to("dns"), equal_to("pcap_stats")), "Unexpected handler")
+        if handler == "all":
+            return policies.generate_pcap_policy_with_all_handlers(name)
+        elif handler == "net":
+            return policies.generate_pcap_policy_with_only_net_handler(name)
+        elif handler == "dhcp":
+            return policies.generate_pcap_policy_with_only_dhcp_handler(name)
+        elif handler == "dns":
+            return policies.generate_pcap_policy_with_only_dns_handler(name)
+        else:
+            return policies.generate_pcap_policy_with_only_pcap_stats_handler(name)


### PR DESCRIPTION
 |    [Create a policy using admin permission with only dns handler](pktvisor/create_a_policy_using_admin_permission_with_only_one_handler.md)    |    👍     |  👍   |   👍   |
|    [Create a policy using admin permission with only net handler](pktvisor/create_a_policy_using_admin_permission_with_only_one_handler.md)    |    👍     |  👍   |   👍   |
|   [Create a policy using admin permission with only dhcp handler](pktvisor/create_a_policy_using_admin_permission_with_only_one_handler.md)    |    👍     |  👍   |   👍   |
|   [Create a policy using admin permission with only pcap handler](pktvisor/create_a_policy_using_admin_permission_with_only_one_handler.md)    |    👍     |  👍   |   👍   |
 |                        [Create a policy without admin permission](pktvisor/create_a_policy_without_admin_permission.md)                        |    👍     |  👍   |   👍   |
|                        [Remove a policy without admin permission](pktvisor/remove_a_policy_without_admin_permission.md)                        |    👍     |  👍   |   👍   |