### PR TITLE
Fix crashpad image

### DIFF
--- a/.github/workflows/debug_build.yml
+++ b/.github/workflows/debug_build.yml
@@ -74,15 +74,15 @@ jobs:
       - name: Debug ref tag
         run: echo ${{ env.REF_TAG }}
 
-      - name: Replace secrets token
+      - name: Replace token
         run: |
-          sed -i -e "s/CP_TOKEN/${{ secrets.CRASHPAD_TOKEN }}/g" docker/entry-cp.sh
+          sed -i -e "s/CP_TOKEN/${{ secrets.CRASHPAD_TOKEN }}/g" docker/run.sh
 
-      - name: escape url
+      - name: Replace escape url
         run: |
           REPLACE=${{ secrets.CRASHPAD_URL }}
           ESCAPED_REPLACE=$(printf '%s\n' "$REPLACE" | sed -e 's/[\/&]/\\&/g')
-          sed -i -e "s/CP_URL/$ESCAPED_REPLACE/g" docker/entry-cp.sh
+          sed -i -e "s/CP_URL/$ESCAPED_REPLACE/g" docker/run.sh
 
       - name: Login to Docker Hub
         uses: docker/login-action@v1

--- a/docker/Dockerfile.crashhandler
+++ b/docker/Dockerfile.crashhandler
@@ -14,6 +14,7 @@ COPY ./crashpad_handler /usr/local/sbin/crashpad_handler
 COPY ./pktvisor-reader /usr/local/sbin/pktvisor-reader
 COPY ./pktvisor-cli /usr/local/bin/pktvisor-cli
 COPY ./docker/entry-cp.sh /entry-cp.sh
+COPY ./docker/run.sh /run.sh
 
 # permissions
 RUN chmod a+x /usr/local/sbin/pktvisord
@@ -21,6 +22,7 @@ RUN chmod a+x /usr/local/sbin/crashpad_handler
 RUN chmod a+x /usr/local/sbin/pktvisor-reader
 RUN chmod a+x /usr/local/bin/pktvisor-cli
 RUN chmod a+x /entry-cp.sh
+RUN chmod a+x /run.sh
 
 ENTRYPOINT [ "/entry-cp.sh" ]
 

--- a/docker/entry-cp.sh
+++ b/docker/entry-cp.sh
@@ -29,9 +29,26 @@ fi
 
 # if binary is pktvisord
 if [ "$BINARY" = 'pktvisord' ]; then
-  shift
-  exec "$BINARY" --cp-token "CP_TOKEN" --cp-url "CP_URL" --cp-path "/usr/local/sbin/crashpad_handler" "$@"
-  sleep 5
+  # eternal loop
+  while true
+  do
+    # pid file dont exist
+    if [ ! -f "/var/run/pktvisord.pid"  ]; then
+      # running pktvisord in background
+      nohup /run.sh "$@" &
+      sleep 2
+      tail -f /nohup.out &
+    else
+      PID=$(cat /var/run/pktvisord.pid)
+      if [ ! -d "/proc/$PID" ]; then
+         # stop container
+         echo "$PID is not running"
+         rm /var/run/pktvisord.pid
+         exit 1
+      fi
+      sleep 10
+    fi
+  done
 else
   shift
   exec "$BINARY" "$@"

--- a/docker/run.sh
+++ b/docker/run.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+shift
+pktvisord --cp-token "CP_TOKEN" --cp-url "CP_URL" --cp-path "/usr/local/sbin/crashpad_handler" "$@" &
+echo $! > /var/run/pktvisord.pid


### PR DESCRIPTION
This PR changes:
- Add a delay (10s) on container to permit crashpad handler execution after pktvisor crash
- Fix pipeline to replace CP secrets to run.sh instead entry-cp.sh