### PR TITLE
don't require a handler to exist for global_config

### DIFF
--- a/src/HandlerManager.h
+++ b/src/HandlerManager.h
@@ -90,7 +90,8 @@ public:
 
             auto handler_plugin = _registry->handler_plugins().find(handler_module_type);
             if (handler_plugin == _registry->handler_plugins().end()) {
-                throw ConfigException(fmt::format("global_handler_config requires stream handler type '{}' which is not available", handler_module_type));
+                spdlog::get("visor")->warn(fmt::format("global_handler_config configures stream handler type '{}' which is not available, ignoring", handler_module_type));
+                return;
             }
 
             if (_global_handler_config.count(handler_module_type) > 0) {

--- a/src/tests/test_policies.cpp
+++ b/src/tests/test_policies.cpp
@@ -895,16 +895,6 @@ TEST_CASE("Policies", "[policies]")
         REQUIRE_THROWS_WITH(registry.policy_manager()->load(config_file["visor"]["policies"]), "stream handler metric groups should contain enable and/or disable tags");
     }
 
-    SECTION("Bad Config: global_handler_config with not valid handler type")
-    {
-        CoreRegistry registry;
-        registry.start(nullptr);
-        YAML::Node config_file = YAML::Load(policies_config_bad12);
-
-        REQUIRE_NOTHROW(registry.tap_manager()->load(config_file["visor"]["taps"], true));
-        REQUIRE_THROWS_WITH(registry.handler_manager()->set_default_handler_config(config_file["visor"]["global_handler_config"]), "global_handler_config requires stream handler type 'dns2' which is not available");
-    }
-
     SECTION("Bad Config: global_handler_config with not valid format")
     {
         CoreRegistry registry;


### PR DESCRIPTION
turn it into a logged warning