### PR TITLE
remove GDB from Docker Image

### DIFF
--- a/docker/Dockerfile.crashhandler
+++ b/docker/Dockerfile.crashhandler
@@ -1,6 +1,6 @@
 FROM debian:bullseye-slim
 
-ENV RUNTIME_DEPS "curl ca-certificates libasan6 gdb"
+ENV RUNTIME_DEPS "curl ca-certificates libasan6"
 
 RUN \
     apt-get update && \


### PR DESCRIPTION
GDB is not required anymore in the image