### PR TITLE
[Fix] github actions version variable

### DIFF
--- a/.github/workflows/build-develop.yml
+++ b/.github/workflows/build-develop.yml
@@ -74,7 +74,7 @@ jobs:
 
     runs-on: ubuntu-latest
     outputs:
-      version_number: ${{ steps.build.outputs.version }}
+      version_number: ${{ env.VERSION }}
     steps:
       - uses: actions/checkout@v2
 

--- a/.github/workflows/build-develop.yml
+++ b/.github/workflows/build-develop.yml
@@ -9,7 +9,6 @@ on:
   push:
     branches:
       - develop
-      - fix-qa-version
 
 env:
   # Customize the CMake build type here (Release, Debug, RelWithDebInfo, etc.)

--- a/.github/workflows/build-develop.yml
+++ b/.github/workflows/build-develop.yml
@@ -106,7 +106,7 @@ jobs:
       - name: Get VERSION
         id: build
         run: |
-          cat cat ${{github.workspace}}/build/VERSION
+          cat ${{github.workspace}}/build/VERSION
           echo "VERSION=`cat ${{github.workspace}}/build/VERSION`" >> $GITHUB_ENV
           echo "::set-output name=version::$(cat ${{github.workspace}}/build/VERSION)"
 

--- a/.github/workflows/build-develop.yml
+++ b/.github/workflows/build-develop.yml
@@ -9,7 +9,7 @@ on:
   push:
     branches:
       - develop
-      - fix-images
+      - fix-qa-version
 
 env:
   # Customize the CMake build type here (Release, Debug, RelWithDebInfo, etc.)
@@ -106,6 +106,7 @@ jobs:
       - name: Get VERSION
         id: build
         run: |
+          cat cat ${{github.workspace}}/build/VERSION
           echo "VERSION=`cat ${{github.workspace}}/build/VERSION`" >> $GITHUB_ENV
           echo "::set-output name=version::$(cat ${{github.workspace}}/build/VERSION)"
 

--- a/.github/workflows/build-develop.yml
+++ b/.github/workflows/build-develop.yml
@@ -105,7 +105,6 @@ jobs:
       - name: Get VERSION
         id: build
         run: |
-          cat ${{github.workspace}}/build/VERSION
           echo "VERSION=`cat ${{github.workspace}}/build/VERSION`" >> $GITHUB_ENV
           echo "::set-output name=version::$(cat ${{github.workspace}}/build/VERSION)"
 


### PR DESCRIPTION
This PR fixes the github variable from set-output to use $GITHUB_ENV, seems that set-output is deprecated.