### PR TITLE
[FIX] release pipeline to generate tag version

### DIFF
--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -500,6 +500,8 @@ jobs:
   package-amd64:
     needs: [ prebuild-package ]
     runs-on: ubuntu-latest
+    outputs:
+      release_version: ${{ env.VERSION }}
     if: github.event_name != 'pull_request'
     steps:
       - name: Attach to workspace
@@ -788,9 +790,16 @@ jobs:
         run: |
           sudo skopeo login -u ${{ secrets.DOCKERHUB_USERNAME }} -p ${{ secrets.DOCKERHUB_TOKEN }} docker.io
 
-      - name: Copy from ghcr.io to docker.io
+      - name: Copy latest from ghcr.io to docker.io
         run: |
           sudo skopeo copy \
           --all \
           docker://ghcr.io/ns1labs/pktvisor:latest \
           docker://docker.io/ns1labs/pktvisor:latest
+          
+      - name: Copy release version from ghcr.io to docker.io
+        run: |
+          sudo skopeo copy \
+          --all \
+          docker://ghcr.io/ns1labs/pktvisor:latest \
+          docker://docker.io/ns1labs/pktvisor:${{ needs.package-amd64.outputs.release_version }}


### PR DESCRIPTION
This PR fixes release pipeline to generate image with tag version number not just latest tag