### PR TITLE
specify required Conan version in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -591,7 +591,7 @@ pktvisor is developed and tested on Linux and OSX. A Windows port is in progress
 
 #### Dependencies
 
-* [Conan](https://conan.io/) C++ package manager
+* [Conan](https://conan.io/) 1.X C++ package manager
 * CMake >= 3.13 (`cmake`)
 * C++ compiler supporting C++17
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -6,7 +6,7 @@ RUN \
     apt-get update && \
     apt-get upgrade --yes --force-yes && \
     apt-get install --yes --force-yes --no-install-recommends ${BUILD_DEPS} && \
-    pip3 install conan
+    pip3 install "conan==1.59.0"
 
 # need git for current hash for VERSION
 COPY ./.git/ /pktvisor-src/.git/


### PR DESCRIPTION
While building pktvisor I encountered an error which led me to discover that pktvisor will not build with the latest version of Conan. In Conan 2.X, `--install-folder` has been [deprecated](https://docs.conan.io/1/migrating_to_2.0/commands.html). I downgraded my local Conan to version 1.59.0 (the latest pre-2.X release) and was able to build successfully.