### PR TITLE
fix Dockerfile

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -53,6 +53,9 @@ RUN mkdir /geo-db
 RUN cd /geo-db && wget https://github.com/ns1labs/geo-asn-database/raw/main/asn.mmdb.gz
 RUN cd /geo-db && wget https://github.com/ns1labs/geo-asn-database/raw/main/city.mmdb.gz
 
+RUN mkdir /iana
+COPY --from=cppbuild /pktvisor-src/src/tests/fixtures/pktvisor-port-service-names.csv /iana/custom-iana.csv
+
 COPY --from=cppbuild /tmp/build/bin/pktvisord /usr/local/sbin/pktvisord
 COPY --from=cppbuild /tmp/build/bin/crashpad_handler /usr/local/sbin/crashpad_handler
 COPY --from=cppbuild /tmp/build/bin/pktvisor-reader /usr/local/sbin/pktvisor-reader


### PR DESCRIPTION
Currently, when using a pktvisor Docker image built locally, the container will exit on start with the following error:

> [2023-03-09 15:20:57.910] [visor] [error] Can not open file "/iana/custom-iana.csv" because "No such file or directory".
> [2023-03-09 15:20:57.910] [visor] [info] exit with failure

This patch resolves the issue.