### PR TITLE
Fix float implicit conversions and some compiler warnings

### DIFF
--- a/src/Metrics.h
+++ b/src/Metrics.h
@@ -12,6 +12,7 @@
 #pragma GCC diagnostic ignored "-Wold-style-cast"
 #pragma GCC diagnostic ignored "-Wunused-function"
 #pragma GCC diagnostic ignored "-Wunused-parameter"
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 #pragma clang diagnostic ignored "-Wrange-loop-analysis"
 #endif
 #include <cpc_sketch.hpp>
@@ -253,7 +254,7 @@ public:
         auto histogram_pmf = _sketch.get_PMF(bins_pmf.first.data(), bins_pmf.second);
         std::vector<T> bins;
         for (size_t i = 0; i < bins_pmf.second; ++i) {
-            if (histogram_pmf[i]) {
+            if (histogram_pmf[i] != 0.0) {
                 bins.push_back(bins_pmf.first[i]);
             }
         }
@@ -274,7 +275,7 @@ public:
         auto histogram_pmf = _sketch.get_PMF(bins_pmf.first.data(), bins_pmf.second);
         std::vector<T> bins;
         for (size_t i = 0; i < bins_pmf.second; ++i) {
-            if (histogram_pmf[i]) {
+            if (histogram_pmf[i] != 0.0) {
                 bins.push_back(bins_pmf.first[i]);
             }
         }
@@ -293,7 +294,7 @@ public:
         out << name_snake({"count"}, add_labels) << ' ' << _sketch.get_n() << std::endl;
     }
 
-    void to_opentelemetry(metrics::v1::ScopeMetrics &scope, timespec &start, timespec &end, LabelMap add_labels = {}) const
+    void to_opentelemetry(metrics::v1::ScopeMetrics &scope, timespec &start, timespec &end, LabelMap add_labels = {}) const override
     {
         if (_sketch.is_empty()) {
             return;
@@ -302,7 +303,7 @@ public:
         auto histogram_pmf = _sketch.get_PMF(bins_pmf.first.data(), bins_pmf.second);
         std::vector<T> bins;
         for (size_t i = 0; i < bins_pmf.second; ++i) {
-            if (histogram_pmf[i]) {
+            if (histogram_pmf[i] != 0.0) {
                 bins.push_back(bins_pmf.first[i]);
             }
         }
@@ -320,7 +321,7 @@ public:
 
         for (std::size_t i = 0; i < bins.size(); ++i) {
             hist_data_point->add_explicit_bounds(bins[i] - pace);
-            hist_data_point->add_bucket_counts(histogram[i] * _sketch.get_n());
+            hist_data_point->add_bucket_counts(static_cast<uint64_t>(histogram[i]) * _sketch.get_n());
         }
         hist_data_point->set_count(_sketch.get_n());
 
@@ -383,7 +384,7 @@ public:
         return _quantile.get_n();
     }
 
-    auto get_quantile(float p) const
+    auto get_quantile(double p) const
     {
         return _quantile.get_quantile(p);
     }

--- a/src/handlers/dns/v1/DnsStreamHandler.h
+++ b/src/handlers/dns/v1/DnsStreamHandler.h
@@ -239,8 +239,8 @@ class DnsMetricsManager final : public visor::AbstractMetricsManager<DnsMetricsB
     using DnsXactID = std::pair<uint32_t, uint16_t>;
     typedef lib::transaction::TransactionManager<DnsXactID, DnsTransaction> DnsTransactionManager;
     std::unique_ptr<DnsTransactionManager> _qr_pair_manager;
-    float _to90th{0.0};
-    float _from90th{0.0};
+    float _to90th{0.0f};
+    float _from90th{0.0f};
 
 public:
     DnsMetricsManager(const Configurable *window_config)

--- a/src/handlers/static_plugins.h
+++ b/src/handlers/static_plugins.h
@@ -1,6 +1,6 @@
 #pragma once
 
-int import_handler_plugins()
+static int import_handler_plugins()
 {
     CORRADE_PLUGIN_IMPORT(VisorHandlerNet);
     CORRADE_PLUGIN_IMPORT(VisorHandlerNetV2);

--- a/src/inputs/pcap/tests/test_parse_pcap.cpp
+++ b/src/inputs/pcap/tests/test_parse_pcap.cpp
@@ -2,6 +2,7 @@
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wold-style-cast"
 #pragma GCC diagnostic ignored "-Wunused-parameter"
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 #pragma clang diagnostic ignored "-Wc99-extensions"
 #pragma clang diagnostic ignored "-Wrange-loop-analysis"
 #endif

--- a/src/inputs/static_plugins.h
+++ b/src/inputs/static_plugins.h
@@ -1,6 +1,6 @@
 #pragma once
 
-int import_input_plugins()
+static int import_input_plugins()
 {
     CORRADE_PLUGIN_IMPORT(VisorInputMock);
     CORRADE_PLUGIN_IMPORT(VisorInputPcap);

--- a/src/tests/test_sketches.cpp
+++ b/src/tests/test_sketches.cpp
@@ -2,6 +2,7 @@
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wold-style-cast"
 #pragma GCC diagnostic ignored "-Wunused-parameter"
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
 #pragma clang diagnostic ignored "-Wrange-loop-analysis"
 #endif
 #include <catch2/catch.hpp>


### PR DESCRIPTION
Doing other project, I've noticed that sometimes implicit conversions are not optimized by the compiler and can impact a bit in performance, even more if it is in a critical path.