### PR TITLE
Update conan CI version to 1.61.0 and re-enable macos build

### DIFF
--- a/.github/actions/build-cpp/Dockerfile
+++ b/.github/actions/build-cpp/Dockerfile
@@ -15,7 +15,7 @@ WORKDIR /pktvisor-src
 RUN apt-get update && \
     apt-get upgrade --yes --force-yes && \
     apt-get install --yes --force-yes --no-install-recommends ${BUILD_DEPS} && \
-    pip3 install 'conan==1.59.0' --force-reinstall
+    pip3 install 'conan==1.61.0' --force-reinstall
     
 RUN chmod +x /entrypoint.sh
 

--- a/.github/workflows/build-develop.yml
+++ b/.github/workflows/build-develop.yml
@@ -39,10 +39,8 @@ jobs:
         with:
           version: 1.61.0
 
-      - name: Append OSX Environment
-        run: |
-           #  echo "LIBRARY_PATH=$LIBRARY_PATH:/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/lib" >> $GITHUB_ENV |
-             echo "SDKROOT=$(xcrun --sdk macosx --show-sdk-path)" >> $GITHUB_ENV
+      - name: Setup OSX Environment
+        run: echo "SDKROOT=$(xcrun --sdk macosx --show-sdk-path)" >> $GITHUB_ENV
          
       - name: Setup Conan Cache
         uses: actions/cache@v3

--- a/.github/workflows/build-develop.yml
+++ b/.github/workflows/build-develop.yml
@@ -27,6 +27,7 @@ jobs:
     runs-on: macos-13
     env:
       DEVELOPER_DIR: /Applications/Xcode_15.0.app/Contents/Developer
+      LIBRARY_PATH: /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/lib
     steps:
       - uses: actions/checkout@v3
 
@@ -42,10 +43,7 @@ jobs:
           version: 1.61.0
 
       - name: Select Xcode version
-        run: ls /usr/bin/c* |
-             ls -la /Applications/Xcode_15.0.app/Contents/Developer/Toolchains |
-             ls -la /Applications/Xcode_15.0.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain |
-             /Applications/Xcode_15.0.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/cc --version
+        run: ls /usr/bin/c*
             
       - name: Setup Conan Cache
         uses: actions/cache@v3

--- a/.github/workflows/build-develop.yml
+++ b/.github/workflows/build-develop.yml
@@ -41,6 +41,9 @@ jobs:
         with:
           version: 1.61.0
 
+      - name: Select Xcode version
+        run: sudo xcode-select -s '/Applications/Xcode_15.0.app/Contents/Developer'
+
       - name: Setup Conan Cache
         uses: actions/cache@v3
         with:

--- a/.github/workflows/build-develop.yml
+++ b/.github/workflows/build-develop.yml
@@ -24,10 +24,7 @@ jobs:
     # cross-platform coverage.
     # See: https://docs.github.com/en/free-pro-team@latest/actions/learn-github-actions/managing-complex-workflows#using-a-build-matrix
 
-    runs-on: macos-13
-    env:
-      DEVELOPER_DIR: /Applications/Xcode_15.0.app/Contents/Developer
-
+    runs-on: macos-latest
     steps:
       - uses: actions/checkout@v3
 
@@ -42,9 +39,11 @@ jobs:
         with:
           version: 1.61.0
 
-      - name: Append LIBRARY_PATH 
-        run: echo "LIBRARY_PATH=$LIBRARY_PATH:/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/lib" >> $GITHUB_ENV
-            
+      - name: Append OSX Environment
+        run: |
+             echo "LIBRARY_PATH=$LIBRARY_PATH:/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/lib" >> $GITHUB_ENV |
+             echo "SDKROOT=$(xcrun --sdk macosx --show-sdk-path)" >> $GITHUB_ENV
+         
       - name: Setup Conan Cache
         uses: actions/cache@v3
         with:

--- a/.github/workflows/build-develop.yml
+++ b/.github/workflows/build-develop.yml
@@ -45,7 +45,7 @@ jobs:
         run: ls /usr/bin/c* |
              ls -la /Applications/Xcode_15.0.app/Contents/Developer/Toolchains |
              ls -la /Applications/Xcode_15.0.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain |
-             /Applications/Xcode_15.0.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/cc  
+             /Applications/Xcode_15.0.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/cc --version
             
       - name: Setup Conan Cache
         uses: actions/cache@v3

--- a/.github/workflows/build-develop.yml
+++ b/.github/workflows/build-develop.yml
@@ -42,8 +42,9 @@ jobs:
           version: 1.61.0
 
       - name: Select Xcode version
-        run: sudo xcode-select -s '/Applications/Xcode_15.0.app/Contents/Developer'
-
+        run: xcode-select --install |
+             ls /usr/bin/g*
+            
       - name: Setup Conan Cache
         uses: actions/cache@v3
         with:

--- a/.github/workflows/build-develop.yml
+++ b/.github/workflows/build-develop.yml
@@ -41,7 +41,7 @@ jobs:
 
       - name: Append OSX Environment
         run: |
-             echo "LIBRARY_PATH=$LIBRARY_PATH:/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/lib" >> $GITHUB_ENV |
+           #  echo "LIBRARY_PATH=$LIBRARY_PATH:/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/lib" >> $GITHUB_ENV |
              echo "SDKROOT=$(xcrun --sdk macosx --show-sdk-path)" >> $GITHUB_ENV
          
       - name: Setup Conan Cache
@@ -60,11 +60,6 @@ jobs:
         # and build directories, but this is only available with CMake 3.13 and higher.
         # The CMake binaries on the Github Actions machines are (as of this writing) 3.12
         run: PKG_CONFIG_PATH=${{github.workspace}}/local/lib/pkgconfig cmake $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=$BUILD_TYPE
-
-      - name: Archive Test Results
-        if: always()
-        shell: bash
-        run: cat /Users/runner/work/pktvisor/pktvisor/build/conan_home/.conan/data/flex/2.6.4/_/_/build/9c74366a6d65a5f05c17d4fe1d17947edff6854f/config.log
 
       - name: Build
         working-directory: ${{github.workspace}}/build

--- a/.github/workflows/build-develop.yml
+++ b/.github/workflows/build-develop.yml
@@ -42,8 +42,10 @@ jobs:
           version: 1.61.0
 
       - name: Select Xcode version
-        run: xcode-select --install |
-             ls /usr/bin/g*
+        run: ls /usr/bin/c* |
+             ls -la /Applications/Xcode_15.0.app/Contents/Developer/Toolchains |
+             ls -la /Applications/Xcode_15.0.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain |
+             /Applications/Xcode_15.0.app/Contents/Developer/Toolchains/XcodeDefault.xctoolchain/usr/bin/cc  
             
       - name: Setup Conan Cache
         uses: actions/cache@v3
@@ -61,6 +63,11 @@ jobs:
         # and build directories, but this is only available with CMake 3.13 and higher.
         # The CMake binaries on the Github Actions machines are (as of this writing) 3.12
         run: PKG_CONFIG_PATH=${{github.workspace}}/local/lib/pkgconfig cmake $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=$BUILD_TYPE
+
+      - name: Archive Test Results
+        if: always()
+        shell: bash
+        run: cat /Users/runner/work/pktvisor/pktvisor/build/conan_home/.conan/data/flex/2.6.4/_/_/build/9c74366a6d65a5f05c17d4fe1d17947edff6854f/config.log
 
       - name: Build
         working-directory: ${{github.workspace}}/build

--- a/.github/workflows/build-develop.yml
+++ b/.github/workflows/build-develop.yml
@@ -24,16 +24,10 @@ jobs:
     # cross-platform coverage.
     # See: https://docs.github.com/en/free-pro-team@latest/actions/learn-github-actions/managing-complex-workflows#using-a-build-matrix
 
-    runs-on: macos-11
+    runs-on: macos-12
     steps:
       - uses: actions/checkout@v3
-      - name: install gcc 12.2
-        run: |  
-          gcc --version
-          brew search gcc
-          brew install gcc@12
-          gcc --version
-      
+
       - name: Create Build Environment
         # Some projects don't allow in-source building, so create a separate build directory
         # We'll use this as our working directory for all subsequent commands
@@ -43,37 +37,37 @@ jobs:
         id: conan
         uses: turtlebrowser/get-conan@main
         with:
-          version: 1.60.1
+          version: 1.61.0
 
-#       - name: Setup Conan Cache
-#         uses: actions/cache@v3
-#         with:
-#           path: ${{github.workspace}}/build/conan_home/
-#           key: conan-${{ runner.os }}-${{ hashFiles('conanfile.txt', '*/conanfile.txt') }}
-#           restore-keys: conan-${{ runner.os }}-
+      - name: Setup Conan Cache
+        uses: actions/cache@v3
+        with:
+          path: ${{github.workspace}}/build/conan_home/
+          key: conan-${{ runner.os }}-${{ hashFiles('conanfile.txt', '*/conanfile.txt') }}
+          restore-keys: conan-${{ runner.os }}-
 
-#       - name: Configure CMake
-#         # Use a bash shell so we can use the same syntax for environment variable
-#         # access regardless of the host operating system
-#         shell: bash
-#         working-directory: ${{github.workspace}}/build
-#         # Note the current convention is to use the -S and -B options here to specify source
-#         # and build directories, but this is only available with CMake 3.13 and higher.
-#         # The CMake binaries on the Github Actions machines are (as of this writing) 3.12
-#         run: PKG_CONFIG_PATH=${{github.workspace}}/local/lib/pkgconfig cmake $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=$BUILD_TYPE
+      - name: Configure CMake
+        # Use a bash shell so we can use the same syntax for environment variable
+        # access regardless of the host operating system
+        shell: bash
+        working-directory: ${{github.workspace}}/build
+        # Note the current convention is to use the -S and -B options here to specify source
+        # and build directories, but this is only available with CMake 3.13 and higher.
+        # The CMake binaries on the Github Actions machines are (as of this writing) 3.12
+        run: PKG_CONFIG_PATH=${{github.workspace}}/local/lib/pkgconfig cmake $GITHUB_WORKSPACE -DCMAKE_BUILD_TYPE=$BUILD_TYPE
 
-#       - name: Build
-#         working-directory: ${{github.workspace}}/build
-#         shell: bash
-#         # Execute the build.  You can specify a specific target with "--target <NAME>"
-#         run: cmake --build . --config $BUILD_TYPE -- -j 2
+      - name: Build
+        working-directory: ${{github.workspace}}/build
+        shell: bash
+        # Execute the build.  You can specify a specific target with "--target <NAME>"
+        run: cmake --build . --config $BUILD_TYPE -- -j 2
 
-#       - name: Test
-#         working-directory: ${{github.workspace}}/build
-#         shell: bash
-#         # Execute tests defined by the CMake configuration.
-#         # See https://cmake.org/cmake/help/latest/manual/ctest.1.html for more detail
-#         run: ctest -C $BUILD_TYPE
+      - name: Test
+        working-directory: ${{github.workspace}}/build
+        shell: bash
+        # Execute tests defined by the CMake configuration.
+        # See https://cmake.org/cmake/help/latest/manual/ctest.1.html for more detail
+        run: ctest -C $BUILD_TYPE
         
   unit-tests-linux:
     # The CMake configure and build commands are platform agnostic and should work equally
@@ -99,7 +93,7 @@ jobs:
         id: conan
         uses: turtlebrowser/get-conan@main
         with:
-          version: 1.59.0
+          version: 1.61.0
 
       - name: linux package install
         run: |
@@ -166,7 +160,7 @@ jobs:
         id: conan
         uses: turtlebrowser/get-conan@main
         with:
-          version: 1.59.0
+          version: 1.61.0
 
       - name: Remove libpcap from conanfile
         shell: bash
@@ -396,7 +390,7 @@ jobs:
         id: conan
         uses: turtlebrowser/get-conan@main
         with:
-          version: 1.59.0
+          version: 1.61.0
 
       - name: Configure CMake to generate VERSION
         shell: bash

--- a/.github/workflows/build-develop.yml
+++ b/.github/workflows/build-develop.yml
@@ -27,7 +27,7 @@ jobs:
     runs-on: macos-13
     env:
       DEVELOPER_DIR: /Applications/Xcode_15.0.app/Contents/Developer
-      LIBRARY_PATH: /Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/lib
+
     steps:
       - uses: actions/checkout@v3
 
@@ -42,8 +42,8 @@ jobs:
         with:
           version: 1.61.0
 
-      - name: Select Xcode version
-        run: ls /usr/bin/c*
+      - name: Append LIBRARY_PATH 
+        run: echo "LIBRARY_PATH=$LIBRARY_PATH:/Library/Developer/CommandLineTools/SDKs/MacOSX.sdk/usr/lib" >> $GITHUB_ENV
             
       - name: Setup Conan Cache
         uses: actions/cache@v3

--- a/.github/workflows/build-develop.yml
+++ b/.github/workflows/build-develop.yml
@@ -24,7 +24,9 @@ jobs:
     # cross-platform coverage.
     # See: https://docs.github.com/en/free-pro-team@latest/actions/learn-github-actions/managing-complex-workflows#using-a-build-matrix
 
-    runs-on: macos-12
+    runs-on: macos-13
+    env:
+      DEVELOPER_DIR: /Applications/Xcode_15.0.app/Contents/Developer
     steps:
       - uses: actions/checkout@v3
 

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -20,7 +20,7 @@ jobs:
   unit-tests:
     strategy:
       matrix:
-        os: [ ubuntu-latest ]
+        os: [ ubuntu-latest, macos-12 ]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3
@@ -32,7 +32,7 @@ jobs:
         id: conan
         uses: turtlebrowser/get-conan@main
         with:
-          version: 1.59.0
+          version: 1.61.0
 
       - name: Setup Conan Cache
         uses: actions/cache@v3
@@ -84,7 +84,7 @@ jobs:
         id: conan
         uses: turtlebrowser/get-conan@main
         with:
-          version: 1.59.0
+          version: 1.61.0
 
       - name: Configure CMake to generate VERSION
         shell: bash
@@ -134,7 +134,7 @@ jobs:
         id: conan
         uses: turtlebrowser/get-conan@main
         with:
-          version: 1.59.0
+          version: 1.61.0
 
       - name: Configure CMake to generate VERSION
         shell: bash
@@ -279,7 +279,7 @@ jobs:
         id: conan
         uses: turtlebrowser/get-conan@main
         with:
-          version: 1.59.0
+          version: 1.61.0
 
       - name: Remove libpcap from conanfile
         shell: bash

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -20,7 +20,7 @@ jobs:
   unit-tests:
     strategy:
       matrix:
-        os: [ ubuntu-latest, macos-13 ]
+        os: [ ubuntu-latest ]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -20,7 +20,7 @@ jobs:
   unit-tests:
     strategy:
       matrix:
-        os: [ ubuntu-latest, macos-12 ]
+        os: [ ubuntu-latest, macos-13 ]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/build_cross.yml
+++ b/.github/workflows/build_cross.yml
@@ -69,7 +69,7 @@ jobs:
           curl -L "${{matrix.toolchain}}" | tar -C toolchain -xz --strip-components=1
 
       - name: Install Conan
-        run: pip install --no-cache-dir 'conan==1.59.0' --force-reinstall
+        run: pip install --no-cache-dir 'conan==1.61.0' --force-reinstall
 
       - name: Create Conan configuration
         run: |

--- a/.github/workflows/build_debug.yml
+++ b/.github/workflows/build_debug.yml
@@ -33,7 +33,7 @@ jobs:
         id: conan
         uses: turtlebrowser/get-conan@main
         with:
-          version: 1.59.0
+          version: 1.61.0
 
       - name: Setup Conan Cache
         uses: actions/cache@v3

--- a/.github/workflows/code-ql.yml
+++ b/.github/workflows/code-ql.yml
@@ -60,7 +60,7 @@ jobs:
     - run: |
         # Run Build - set up dependencies, env vars, compile, and make test
         #install conan
-        pip install --no-cache-dir 'conan==1.59.0' --force-reinstall
+        pip install --no-cache-dir 'conan==1.61.0' --force-reinstall
         # create conan config
         CONAN_V2_MODE=1 conan config init
         conan config set general.revisions_enabled=1

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -6,7 +6,7 @@ RUN \
     apt-get update && \
     apt-get upgrade --yes --force-yes && \
     apt-get install --yes --force-yes --no-install-recommends ${BUILD_DEPS} && \
-    pip3 install "conan==1.59.0"
+    pip3 install "conan==1.61.0"
 
 # need git for current hash for VERSION
 COPY ./.git/ /pktvisor-src/.git/


### PR DESCRIPTION
- Update Conan version from 1.59.0 to 1.61.0
   -'Cause there were fixes regarding macOS: https://github.com/conan-io/conan/pull/14533

- Re-enable macos build. Basically, I've reverted: https://github.com/orb-community/pktvisor/commit/10de22988ca3aff88b458c19121d423b55c807f8

- Fix macOS CI build by proper setup SDKROOT env