### PR TITLE
OTLP: Move policy name to attributes

### DIFF
--- a/src/CoreServer.cpp
+++ b/src/CoreServer.cpp
@@ -448,6 +448,7 @@ void CoreServer::_setup_routes(const PrometheusConfig &prom_config)
                 try {
                     auto [policy, lock] = _registry->policy_manager()->module_get_locked(p_mname);
                     auto scope = resource.add_scope_metrics();
+                    scope->mutable_scope()->set_name("pktvisor/" + p_mname);
                     auto attr = scope->mutable_scope()->add_attributes();
                     attr->set_key("policy_name");
                     attr->mutable_value()->set_string_value(p_mname);

--- a/src/CoreServer.cpp
+++ b/src/CoreServer.cpp
@@ -448,7 +448,9 @@ void CoreServer::_setup_routes(const PrometheusConfig &prom_config)
                 try {
                     auto [policy, lock] = _registry->policy_manager()->module_get_locked(p_mname);
                     auto scope = resource.add_scope_metrics();
-                    scope->mutable_scope()->set_name(p_mname);
+                    auto attr = scope->mutable_scope()->add_attributes();
+                    attr->set_key("policy_name");
+                    attr->mutable_value()->set_string_value(p_mname);
                     policy->opentelemetry_metrics(*scope);
                 } catch (const std::exception &) {
                     return false;


### PR DESCRIPTION
- Move pktvisor policy_name to attributes.
- No name is set for the scope anymore (i'm not sure if it is required)

- It requires validation! cc @manrodrigues 
