### PR TITLE
Update dependency libraries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,6 @@ docs/internals/html
 appimage/*.AppImage
 /test-config*.yaml
 localconfig/
+.cache/
+.vscode/
+build/

--- a/conanfile.txt
+++ b/conanfile.txt
@@ -1,12 +1,12 @@
 [requires]
-catch2/3.4.0
+catch2/3.5.0
 corrade/2020.06
-cpp-httplib/0.14.1
+cpp-httplib/0.14.3
 docopt.cpp/0.6.3
 fast-cpp-csv-parser/cci.20211104
 json-schema-validator/2.2.0
-libmaxminddb/1.7.1
-nlohmann_json/3.11.2
+libmaxminddb/1.8.0
+nlohmann_json/3.11.3
 openssl/1.1.1w
 opentelemetry-proto/1.0.0
 pcapplusplus/23.09
@@ -17,6 +17,7 @@ uvw/3.2.0
 libpcap/1.10.4
 yaml-cpp/0.8.0
 robin-hood-hashing/3.11.5
+libcurl/8.5.0
 crashpad/cci.20220219
 zlib/[>=1.2.10 <1.3]
 

--- a/conanfile.txt
+++ b/conanfile.txt
@@ -6,7 +6,7 @@ docopt.cpp/0.6.3
 fast-cpp-csv-parser/cci.20211104
 json-schema-validator/2.2.0
 libmaxminddb/1.8.0
-nlohmann_json/3.11.3
+nlohmann_json/3.11.2
 openssl/1.1.1w
 opentelemetry-proto/1.0.0
 pcapplusplus/23.09


### PR DESCRIPTION
- crashpad requires libcurl, so I've specified the latest version to that to fix security issues