### PR TITLE
chore: codeql sarif filter

### DIFF
--- a/.github/workflows/code-ql.yml
+++ b/.github/workflows/code-ql.yml
@@ -2,6 +2,9 @@
 name: "CodeQL"
 
 on:
+  pull_request:
+    branches:
+      - develop
   schedule:
   #run 5 minutes after midnight daily
     - cron: '5 0 * * *'
@@ -117,7 +120,7 @@ jobs:
       uses: advanced-security/filter-sarif@v1
       with:
         patterns: |
-          -pktvisor/build/**/*
+          -pktvisor/build/conan_home/**/*
         input: sarif-results/cpp.sarif
         output: sarif-results/cpp.sarif
 

--- a/.github/workflows/code-ql.yml
+++ b/.github/workflows/code-ql.yml
@@ -2,6 +2,9 @@
 name: "CodeQL"
 
 on:
+  pull_request:
+    branches:
+      - develop
   schedule:
   #run 5 minutes after midnight daily
     - cron: '5 0 * * *'
@@ -108,3 +111,28 @@ jobs:
 
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v3
+      with:
+        category: "/language:cpp"
+        output: sarif-results
+        upload: failure-only
+
+    - name: filter-sarif
+      uses: advanced-security/filter-sarif@v1
+      with:
+        patterns: |
+          +**/*.cpp
+          -build/**/*
+        input: sarif-results/cpp.sarif
+        output: sarif-results/cpp.sarif
+
+    - name: Upload SARIF
+      uses: github/codeql-action/upload-sarif@v3
+      with:
+        sarif_file: sarif-results/cpp.sarif
+
+    - name: Upload loc as a Build Artifact
+      uses: actions/upload-artifact@v4
+      with:
+        name: sarif-results
+        path: sarif-results
+        retention-days: 1

--- a/.github/workflows/code-ql.yml
+++ b/.github/workflows/code-ql.yml
@@ -120,8 +120,7 @@ jobs:
       uses: advanced-security/filter-sarif@v1
       with:
         patterns: |
-          +**/*.cpp
-          -build/**/*
+          -pktvisor/build/**/*
         input: sarif-results/cpp.sarif
         output: sarif-results/cpp.sarif
 

--- a/.github/workflows/code-ql.yml
+++ b/.github/workflows/code-ql.yml
@@ -2,9 +2,6 @@
 name: "CodeQL"
 
 on:
-  pull_request:
-    branches:
-      - develop
   schedule:
   #run 5 minutes after midnight daily
     - cron: '5 0 * * *'


### PR DESCRIPTION
remove build/ folder from sarif scan