### PR TITLE
chore: update pktvisor readme and info

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,5 @@
 ## How to Contribute
-At NS1, it makes us very happy to get pull requests, and we appreciate the time
+At NetBox Labs, it makes us very happy to get pull requests, and we appreciate the time
 and effort it takes to put one together. Below are a few guidelines that can
 help get your pull request approved and merged quickly and easily.
 
@@ -68,11 +68,11 @@ help ensure that requests are resolved quickly and efficiently.
   and/or to modify the scope of the request. Please keep in mind that project
   status consideration or conflicting priorities may require us to close or
   defer work on the new or reopened issue. If that happens, feel free to reach
-  out of support@ns1.com for more information.
+  out of support@netboxlabs.com for more information.
 
 ## Tags on issues
 
-In some projects we (NS1) may apply basic tags on some issues, for
+In some projects we may apply basic tags on some issues, for
 organizational purposes. Note: we do not use tags to indicate timelines or
 priorities.
 

--- a/README.md
+++ b/README.md
@@ -152,7 +152,7 @@ chmod +x pktvisor-reader-x86_64
 We are working on support for additional operating systems, CPU architectures and packaging systems. If you do not see your binary available, please see the [Build](#build) section below to build your own.
 
 If you have a preferred installation method that you would like to see support
-for, [please create an issue](https://github.com/ns1/pktvisor/issues/new).
+for, [please create an issue](https://github.com/netboxlabs/pktvisor/issues/new).
 
 ### Execute Pktvisord binary without root
 Pktvisord uses libpcap to capture PCAP from the desired interface. To do so, it needs system network capture permissions.
@@ -630,8 +630,11 @@ process.
 Please open Pull Requests against the `develop` branch. If you are considering a larger
 contribution, [please contact us](#contact-us) to discuss your design.
 
-See the [NS1 Contribution Guidelines](https://github.com/ns1/community) for more information.
+See the [Contribution Guidelines](CONTRIBUTING.md) for more information.
 
 ## License
 
 This code is released under Mozilla Public License 2.0. You can find terms and conditions in the LICENSE file.
+
+## Required Notice
+Copyright NetBox Labs, Inc.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,5 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+Please send any suspected vulnerability report to security@netboxlabs.com


### PR DESCRIPTION
This pull request updates project documentation to reflect the transition from NS1 to NetBox Labs, ensuring that all references, links, and contact information are current and accurate. It also adds a new security policy and required copyright notice.

Branding and contact updates:

* Updated all references from "NS1" to "NetBox Labs" in `CONTRIBUTING.md` and `README.md`, including contact emails and issue links. [[1]](diffhunk://#diff-eca12c0a30e25b4b46522ebf89465a03ba72a03f540796c979137931d8f92055L2-R2) [[2]](diffhunk://#diff-eca12c0a30e25b4b46522ebf89465a03ba72a03f540796c979137931d8f92055L71-R75) [[3]](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5L155-R155)
* Replaced links to NS1 contribution guidelines with links to the local `CONTRIBUTING.md` file in `README.md`.

Legal and security documentation:

* Added a "Required Notice" for NetBox Labs copyright in `README.md`.
* Introduced a new `SECURITY.md` file with instructions for reporting vulnerabilities to security@netboxlabs.com.