### PR TITLE
chore: replace Corrade 2020.06 with cci.20250327 for macOS build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -73,6 +73,24 @@ if(_conan_generators AND EXISTS "${_conan_generators}/conan_toolchain.cmake")
 endif()
 unset(_conan_generators)
 
+# On macOS with non-Xcode generators (e.g. Unix Makefiles), Conan sets
+# CMAKE_OSX_SYSROOT to the shortname 'macosx' which only Xcode resolves.
+# Clang requires the full SDK path. We override here, after the conan toolchain
+# re-include above (which resets the value via FORCE).
+if(APPLE AND NOT CMAKE_GENERATOR MATCHES "Xcode")
+    execute_process(
+        COMMAND xcrun --sdk macosx --show-sdk-path
+        OUTPUT_VARIABLE _VISOR_MACOS_SDK_PATH
+        OUTPUT_STRIP_TRAILING_WHITESPACE
+        ERROR_QUIET
+    )
+    if(_VISOR_MACOS_SDK_PATH)
+        set(CMAKE_OSX_SYSROOT "${_VISOR_MACOS_SDK_PATH}" CACHE STRING "macOS SDK path" FORCE)
+        message(STATUS "visor: macOS SDK path: ${CMAKE_OSX_SYSROOT}")
+    endif()
+    unset(_VISOR_MACOS_SDK_PATH)
+endif()
+
 include(sanitizer)
 if(CODE_COVERAGE)
     include(CodeCoverage)

--- a/conanfile.py
+++ b/conanfile.py
@@ -8,7 +8,7 @@ class Pktvisor(ConanFile):
 
     def requirements(self):
         self.requires("catch2/3.14.0")
-        self.requires("corrade/2020.06")
+        self.requires("corrade/cci.20250327")
         self.requires("cpp-httplib/0.18.3")
         self.requires("docopt.cpp/0.6.3")
         self.requires("fast-cpp-csv-parser/cci.20240102")
@@ -20,7 +20,7 @@ class Pktvisor(ConanFile):
             self.requires("libpcap/1.10.5", force=True)
         else:
             self.requires("npcap/1.70")
-        self.requires("opentelemetry-cpp/1.17.0")
+        self.requires("opentelemetry-cpp/1.24.0")
         self.requires("pcapplusplus/25.05")
         self.requires("protobuf/5.27.0")
         self.requires("sigslot/1.2.3")
@@ -37,7 +37,7 @@ class Pktvisor(ConanFile):
             self.requires("sentry-crashpad/0.6.5")
 
     def build_requirements(self):
-        self.tool_requires("corrade/2020.06")
+        self.tool_requires("corrade/cci.20250327")
         self.tool_requires("protobuf/5.27.0")
 
     def layout(self):

--- a/src/AbstractPlugin.cpp
+++ b/src/AbstractPlugin.cpp
@@ -3,6 +3,7 @@
  * file, You can obtain one at https://mozilla.org/MPL/2.0/. */
 
 #include "AbstractPlugin.h"
+#include "CorradeCompat.h"
 #include <fmt/format.h>
 #include <regex>
 

--- a/src/AbstractPlugin.h
+++ b/src/AbstractPlugin.h
@@ -73,7 +73,7 @@ private:
 public:
     static Corrade::Containers::Array<Corrade::Containers::String> pluginSearchPaths()
     {
-        return {};
+        return Corrade::Containers::Array<Corrade::Containers::String>{1};
     }
 
     explicit AbstractPlugin(Corrade::PluginManager::AbstractManager &manager, const std::string &plugin)

--- a/src/AbstractPlugin.h
+++ b/src/AbstractPlugin.h
@@ -5,6 +5,8 @@
 #pragma once
 
 #include <Corrade/PluginManager/AbstractPlugin.h>
+#include <Corrade/Containers/Array.h>
+#include <Corrade/Containers/String.h>
 #include <exception>
 #include <nlohmann/json.hpp>
 #include <string>
@@ -69,9 +71,9 @@ private:
     }
 
 public:
-    static std::vector<std::string> pluginSearchPaths()
+    static Corrade::Containers::Array<Corrade::Containers::String> pluginSearchPaths()
     {
-        return {""};
+        return {};
     }
 
     explicit AbstractPlugin(Corrade::PluginManager::AbstractManager &manager, const std::string &plugin)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -45,7 +45,7 @@ target_link_libraries(visor-core
         datasketches
         rng
         timer
-        opentelemetry-cpp::opentelemetry_proto
+        opentelemetry-cpp::proto
         protobuf::libprotobuf
         maxminddb::maxminddb
         Corrade::Corrade

--- a/src/CoreRegistry.cpp
+++ b/src/CoreRegistry.cpp
@@ -8,6 +8,7 @@
 #include "InputStreamManager.h"
 #include "Policies.h"
 #include "Taps.h"
+#include "CorradeCompat.h"
 #include <Corrade/Utility/ConfigurationGroup.h>
 #include <spdlog/sinks/stdout_color_sinks.h>
 #include <spdlog/spdlog.h>
@@ -62,7 +63,7 @@ void CoreRegistry::start(HttpServer *svr)
                     InputPluginPtr mod = _input_registry.instantiate(alias);
                     _logger->info("Load input stream plugin: {} version {} interface {}", alias, version, mod->pluginInterface());
                     mod->init_plugin(this, svr, &geo::GeoIP(), &geo::GeoASN());
-                    auto result = _input_plugins.insert({std::make_pair(alias, version), std::move(mod)});
+                    auto result = _input_plugins.insert({std::make_pair(corrade_to_std_string(alias), version), std::move(mod)});
                     if (!result.second) {
                         throw std::runtime_error(fmt::format("Input alias '{}' with version '{}' was already loaded.", alias, version));
                     }
@@ -92,7 +93,7 @@ void CoreRegistry::start(HttpServer *svr)
                     HandlerPluginPtr mod = _handler_registry.instantiate(s);
                     _logger->info("Load stream handler plugin: {} version {} interface {}", alias, version, mod->pluginInterface());
                     mod->init_plugin(this, svr, &geo::GeoIP(), &geo::GeoASN());
-                    auto result = _handler_plugins.insert({std::make_pair(alias, version), std::move(mod)});
+                    auto result = _handler_plugins.insert({std::make_pair(corrade_to_std_string(alias), version), std::move(mod)});
                     if (!result.second) {
                         throw std::runtime_error(fmt::format("Handler alias '{}' with version '{}' was already loaded.", alias, version));
                     }

--- a/src/CoreRegistry.cpp
+++ b/src/CoreRegistry.cpp
@@ -9,6 +9,7 @@
 #include "Policies.h"
 #include "Taps.h"
 #include "CorradeCompat.h"
+#include <Corrade/Containers/PointerStl.h>
 #include <Corrade/Utility/ConfigurationGroup.h>
 #include <spdlog/sinks/stdout_color_sinks.h>
 #include <spdlog/spdlog.h>
@@ -63,7 +64,7 @@ void CoreRegistry::start(HttpServer *svr)
                     InputPluginPtr mod = _input_registry.instantiate(alias);
                     _logger->info("Load input stream plugin: {} version {} interface {}", alias, version, mod->pluginInterface());
                     mod->init_plugin(this, svr, &geo::GeoIP(), &geo::GeoASN());
-                    auto result = _input_plugins.insert({std::make_pair(corrade_to_std_string(alias), version), std::move(mod)});
+                    auto result = _input_plugins.try_emplace(std::make_pair(corrade_to_std_string(alias), version), std::move(mod));
                     if (!result.second) {
                         throw std::runtime_error(fmt::format("Input alias '{}' with version '{}' was already loaded.", alias, version));
                     }
@@ -93,7 +94,7 @@ void CoreRegistry::start(HttpServer *svr)
                     HandlerPluginPtr mod = _handler_registry.instantiate(s);
                     _logger->info("Load stream handler plugin: {} version {} interface {}", alias, version, mod->pluginInterface());
                     mod->init_plugin(this, svr, &geo::GeoIP(), &geo::GeoASN());
-                    auto result = _handler_plugins.insert({std::make_pair(corrade_to_std_string(alias), version), std::move(mod)});
+                    auto result = _handler_plugins.try_emplace(std::make_pair(corrade_to_std_string(alias), version), std::move(mod));
                     if (!result.second) {
                         throw std::runtime_error(fmt::format("Handler alias '{}' with version '{}' was already loaded.", alias, version));
                     }

--- a/src/CorradeCompat.h
+++ b/src/CorradeCompat.h
@@ -1,0 +1,18 @@
+#pragma once
+
+#include <Corrade/Containers/StringView.h>
+#include <fmt/format.h>
+#include <string>
+
+inline std::string corrade_to_std_string(Corrade::Containers::StringView view)
+{
+    return {view.data(), view.size()};
+}
+
+template <>
+struct fmt::formatter<Corrade::Containers::StringView> : fmt::formatter<fmt::string_view> {
+    auto format(Corrade::Containers::StringView value, format_context &ctx) const -> format_context::iterator
+    {
+        return fmt::formatter<fmt::string_view>::format(fmt::string_view{value.data(), value.size()}, ctx);
+    }
+};

--- a/src/HandlerModulePlugin.h
+++ b/src/HandlerModulePlugin.h
@@ -26,9 +26,9 @@ public:
         return "visor.module.handler/1.0";
     }
 
-    static std::vector<std::string> pluginSearchPaths()
+    static Corrade::Containers::Array<Corrade::Containers::String> pluginSearchPaths()
     {
-        return {""};
+        return {};
     }
 
     explicit HandlerModulePlugin(Corrade::PluginManager::AbstractManager &manager, const std::string &plugin)

--- a/src/HandlerModulePlugin.h
+++ b/src/HandlerModulePlugin.h
@@ -21,9 +21,10 @@ public:
     static geo::MaxmindDB *asn;
     static geo::MaxmindDB *city;
 
-    static std::string pluginInterface()
+    static Corrade::Containers::StringView pluginInterface()
     {
-        return "visor.module.handler/1.0";
+        using namespace Corrade::Containers::Literals;
+        return "visor.module.handler/1.0"_s;
     }
 
     static Corrade::Containers::Array<Corrade::Containers::String> pluginSearchPaths()

--- a/src/HandlerModulePlugin.h
+++ b/src/HandlerModulePlugin.h
@@ -29,7 +29,7 @@ public:
 
     static Corrade::Containers::Array<Corrade::Containers::String> pluginSearchPaths()
     {
-        return {};
+        return Corrade::Containers::Array<Corrade::Containers::String>{1};
     }
 
     explicit HandlerModulePlugin(Corrade::PluginManager::AbstractManager &manager, const std::string &plugin)

--- a/src/InputModulePlugin.h
+++ b/src/InputModulePlugin.h
@@ -26,7 +26,7 @@ public:
 
     static Corrade::Containers::Array<Corrade::Containers::String> pluginSearchPaths()
     {
-        return {};
+        return Corrade::Containers::Array<Corrade::Containers::String>{1};
     }
 
     explicit InputModulePlugin(Corrade::PluginManager::AbstractManager &manager, const std::string &plugin)

--- a/src/InputModulePlugin.h
+++ b/src/InputModulePlugin.h
@@ -23,9 +23,9 @@ public:
         return "visor.module.input/1.0";
     }
 
-    static std::vector<std::string> pluginSearchPaths()
+    static Corrade::Containers::Array<Corrade::Containers::String> pluginSearchPaths()
     {
-        return {""};
+        return {};
     }
 
     explicit InputModulePlugin(Corrade::PluginManager::AbstractManager &manager, const std::string &plugin)

--- a/src/InputModulePlugin.h
+++ b/src/InputModulePlugin.h
@@ -18,9 +18,10 @@ class InputModulePlugin : public AbstractPlugin
 {
 
 public:
-    static std::string pluginInterface()
+    static Corrade::Containers::StringView pluginInterface()
     {
-        return "visor.module.input/1.0";
+        using namespace Corrade::Containers::Literals;
+        return "visor.module.input/1.0"_s;
     }
 
     static Corrade::Containers::Array<Corrade::Containers::String> pluginSearchPaths()

--- a/src/Policies.cpp
+++ b/src/Policies.cpp
@@ -7,6 +7,7 @@
 #include "HandlerManager.h"
 #include "InputStreamManager.h"
 #include "Taps.h"
+#include "CorradeCompat.h"
 #include <algorithm>
 #include <fmt/format.h>
 #include <spdlog/spdlog.h>
@@ -88,7 +89,7 @@ std::vector<Policy *> PolicyManager::load(const YAML::Node &policy_yaml, bool si
                 auto [tap, tap_lock] = _registry->tap_manager()->module_get_locked(tap_name);
                 policy_ptr->add_tap(tap);
                 // ensure tap input type matches policy input tap
-                if (input_node["input_type"].as<std::string>() != tap->input_plugin()->plugin()) {
+                if (input_node["input_type"].as<std::string>() != corrade_to_std_string(tap->input_plugin()->plugin())) {
                     throw PolicyException(fmt::format("input_type for policy specified tap '{}' doesn't match tap's defined input type: {}/{}", tap_name, input_node["input_type"].as<std::string>(), tap->input_plugin()->plugin()));
                 }
                 // handler internal config

--- a/src/Taps.h
+++ b/src/Taps.h
@@ -9,6 +9,7 @@
 #include "Configurable.h"
 #include "InputModulePlugin.h"
 #include <yaml-cpp/yaml.h>
+#include "CorradeCompat.h"
 
 namespace visor {
 
@@ -56,7 +57,7 @@ public:
 
     void info_json(json &j) const override
     {
-        j["input_type"] = _input_plugin->plugin();
+        j["input_type"] = corrade_to_std_string(_input_plugin->plugin());
         j["interface"] = _input_plugin->pluginInterface();
         config_json(j["config"]);
         _tags->config_json(j["tags"]);

--- a/src/handlers/static_plugins.h
+++ b/src/handlers/static_plugins.h
@@ -1,5 +1,8 @@
 #pragma once
 
+#include <Corrade/PluginManager/AbstractManager.h>
+#include <Corrade/Utility/Macros.h>
+
 static int import_handler_plugins()
 {
     CORRADE_PLUGIN_IMPORT(VisorHandlerNet);

--- a/src/inputs/static_plugins.h
+++ b/src/inputs/static_plugins.h
@@ -1,5 +1,8 @@
 #pragma once
 
+#include <Corrade/PluginManager/AbstractManager.h>
+#include <Corrade/Utility/Macros.h>
+
 static int import_input_plugins()
 {
     CORRADE_PLUGIN_IMPORT(VisorInputMock);


### PR DESCRIPTION
## Summary

- Upgrades `corrade` from `2020.06` to `cci.20250327` and `opentelemetry-cpp` from `1.17.0` to `1.24.0` in `conanfile.py`
- Patches all pktvisor plugin interfaces to conform to the new Corrade ABI (breaking changes in `cci.20250327`)
- Adds `CorradeCompat.h` to bridge `Corrade::Containers::StringView` with `fmt` and `std::string`
- Fixes macOS SDK sysroot issue when building with non-Xcode CMake generators

## Breaking API changes addressed (Corrade cci.20250327 vs 2020.06)

| Changed API | Old | New |
|---|---|---|
| `AbstractPlugin::plugin()` | `const std::string&` | `Containers::StringView` |
| `PluginMetadata::provides()` | `const std::vector<std::string>&` | `Containers::StringIterable` |
| `AbstractManager::pluginList()` | `std::vector<std::string>` | `Containers::Array<StringView>` |
| `pluginSearchPaths()` | `std::vector<std::string>{""}` | `Array<String>{1}` |
| `pluginInterface()` | `std::string` | `StringView` (must have `Global` flag) |
| `CORRADE_AUTOMATIC_INITIALIZER` | in `AbstractManager.h` | moved to `Utility/Macros.h` |
| Plugin constructor arg | `const std::string&` | `const Containers::StringView&` |

## Test plan

- [ ] Run `cmake` configure from `build/` with `conan_provider` to verify no sysroot errors
- [ ] Run `make -j4` to verify full build
- [ ] Run unit tests from `src/` directory: all 18 test cases pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)