### PR TITLE
chore: update opentelemetry-cpp, protobuf, GitHub Actions and fix flaky netflow test

### DIFF
--- a/.github/workflows/build-develop.yml
+++ b/.github/workflows/build-develop.yml
@@ -22,13 +22,13 @@ jobs:
   unit-tests-mac:
     runs-on: macos-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Create Build Environment
         run: cmake -E make_directory ${{github.workspace}}/build
 
       - name: Python Setup
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v6
         with:
           python-version: '3.10'
 
@@ -40,7 +40,7 @@ jobs:
         run: echo "SDKROOT=$(xcrun --sdk macosx --show-sdk-path)" >> $GITHUB_ENV
          
       - name: Setup Conan Cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ${{github.workspace}}/build/p/
           key: conan-${{ runner.os }}-${{ hashFiles('conanfile.py', '*/conanfile.py') }}
@@ -70,7 +70,7 @@ jobs:
       version_number: ${{ env.VERSION }}
       commit_hash: ${{ env.COMMIT }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Create Build Environment
         run: cmake -E make_directory ${{github.workspace}}/build
@@ -80,7 +80,7 @@ jobs:
         uses: turtlebrowser/get-conan@c171f295f3f507360ee018736a6608731aa2109d #v1.2
 
       - name: Setup Conan Cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ${{github.workspace}}/build/p/
           key: conan-${{ runner.os }}-amd64-${{ hashFiles('conanfile.py', '*/conanfile.py') }}
@@ -112,7 +112,7 @@ jobs:
     outputs:
       version_number: ${{ env.VERSION }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Create Build Environment
         run: cmake -E make_directory ${{github.workspace}}\build
@@ -128,7 +128,7 @@ jobs:
           sed -i 's/compiler.cppstd=14/compiler.cppstd=17/' "$(conan profile path default)"
 
       - name: Setup Conan Cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ${{github.workspace}}/build/p/
           key: conan-${{ runner.os }}-${{ hashFiles('conanfile.py', '*/conanfile.py') }}
@@ -167,7 +167,7 @@ jobs:
           Get-ChildItem -Force ${{github.workspace}}\build\bin
                          
       - name: Persist to workspace
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: windows-build
           path: |
@@ -181,10 +181,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:    
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Attach to workspace
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: windows-build
           
@@ -229,13 +229,13 @@ jobs:
     outputs:
       version_number: ${{ env.VERSION }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Create Build Environment
         run: cmake -E make_directory ${{github.workspace}}/build
 
       - name: Setup Conan Cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ${{github.workspace}}/build/p/
           key: conan-${{ runner.os }}-amd64-${{ hashFiles('conanfile.py', '*/conanfile.py') }}
@@ -268,12 +268,12 @@ jobs:
 
       - name: Docker meta
         id: meta
-        uses: docker/metadata-action@369eb591f429131d6889c46b94e711f089e6ca96 #v5.6.1
+        uses: docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf #v6.0.0
         with:
           images: ${{ env.IMAGE_NAME }}
 
       - name: Login to Docker Hub
-        uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 #v3.3.0
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 #v4.1.0
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
@@ -289,14 +289,14 @@ jobs:
           sed -i -e "s/CP_URL/$ESCAPED_REPLACE/g" docker/run.sh
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@49b3bc8e6bdd4a60e6116a5414239cba5943d3cf #v3.2.0
+        uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a #v4.0.0
 
       - name: Set up Docker Buildx
         id: buildx
-        uses: docker/setup-buildx-action@6524bf65af31da8d45b59e8c27de4bd072b392f5 #v3.8.0
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd #v4.0.0
 
       - name: Build + push - pktvisor (multi-arch)
-        uses: docker/build-push-action@48aba3b46d1b1fec4febb7c5d0c644b249a11355 #v6.10.0
+        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f #v7.1.0
         id: docker_build
         with:
           builder: ${{ steps.buildx.outputs.name }}
@@ -313,7 +313,7 @@ jobs:
             touch "/tmp/digests/${digest#sha256:}"
 
       - name: Upload digest
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
             name: digests-linux-amd64
             path: /tmp/digests/*
@@ -324,7 +324,7 @@ jobs:
     needs: [ merge-packages ]
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       
       - name: Create Build Environment
         run: cmake -E make_directory ${{github.workspace}}/build
@@ -334,7 +334,7 @@ jobs:
         uses: turtlebrowser/get-conan@c171f295f3f507360ee018736a6608731aa2109d #v1.2
 
       - name: Setup Conan Cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ${{github.workspace}}/build/p/
           key: conan-${{ runner.os }}-amd64-${{ hashFiles('conanfile.py', '*/conanfile.py') }}
@@ -375,13 +375,13 @@ jobs:
       - name: Upload pktvisor-cli artifact
         env:
           BINARY_NAME: pktvisor-cli-linux-x86_64-${{ env.VERSION }}
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: ${{ env.BINARY_NAME }}
           path: ${{github.workspace}}/${{ env.BINARY_NAME }}
           
       - name: Login to Docker Hub
-        uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 #v3.3.0
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 #v4.1.0
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
@@ -401,7 +401,7 @@ jobs:
           mv pktvisor-x86_64.AppImage pktvisor-x86_64-${{ env.VERSION }}.AppImage
 
       - name: Upload AppImage artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: pktvisor-x86_64-${{ env.VERSION }}.AppImage
           path: ${{github.workspace}}/appimage/pktvisor-x86_64-${{ env.VERSION }}.AppImage
@@ -416,13 +416,13 @@ jobs:
           sudo chown -R $USER:$USER $GITHUB_WORKSPACE
 
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Create Build Environment
         run: cmake -E make_directory ${{github.workspace}}/build
 
       - name: Setup Conan Cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ${{github.workspace}}/build/p/
           key: conan-${{ runner.os }}-arm64-${{ hashFiles('conanfile.py', '*/conanfile.py') }}
@@ -452,22 +452,22 @@ jobs:
 
       - name: Docker meta
         id: meta
-        uses: docker/metadata-action@369eb591f429131d6889c46b94e711f089e6ca96 #v5.6.1
+        uses: docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf #v6.0.0
         with:
           images: ${{ env.IMAGE_NAME }}
 
       - name: Login to Docker Hub
-        uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 #v3.3.0
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 #v4.1.0
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@49b3bc8e6bdd4a60e6116a5414239cba5943d3cf #v3.2.0
+        uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a #v4.0.0
 
       - name: Set up Docker Buildx
         id: buildx
-        uses: docker/setup-buildx-action@6524bf65af31da8d45b59e8c27de4bd072b392f5 #v3.8.0
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd #v4.0.0
         
       - name: Replace token
         run: |
@@ -481,7 +481,7 @@ jobs:
 
       - name: Build + push - pktvisor (multi-arch)
         id: docker_build
-        uses: docker/build-push-action@48aba3b46d1b1fec4febb7c5d0c644b249a11355 #v6.10.0
+        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f #v7.1.0
         with:
           builder: ${{ steps.buildx.outputs.name }}
           context: .
@@ -497,7 +497,7 @@ jobs:
             touch "/tmp/digests/${digest#sha256:}"
 
       - name: Upload digest
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
             name: digests-linux-arm64
             path: /tmp/digests/*
@@ -509,25 +509,25 @@ jobs:
     needs: [unit-tests-linux, package-amd64, package-arm64]
     steps:
       - name: Download digests
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           path: /tmp/digests
           pattern: digests-*
           merge-multiple: true
 
       - name: Login to Docker Hub
-        uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 #v3.3.0
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 #v4.1.0
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Set up Docker Buildx
         id: buildx
-        uses: docker/setup-buildx-action@6524bf65af31da8d45b59e8c27de4bd072b392f5 #v3.8.0
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd #v4.0.0
 
       - name: Docker meta
         id: meta
-        uses: docker/metadata-action@369eb591f429131d6889c46b94e711f089e6ca96 #v5.6.1
+        uses: docker/metadata-action@030e881283bb7a6894de51c315a6bfe6a94e05cf #v6.0.0
         with:
           images: ${{ env.IMAGE_NAME }}
           tags: |

--- a/.github/workflows/build-develop.yml
+++ b/.github/workflows/build-develop.yml
@@ -121,6 +121,12 @@ jobs:
         id: conan
         uses: turtlebrowser/get-conan@c171f295f3f507360ee018736a6608731aa2109d #v1.2
 
+      - name: Setup Conan Profile
+        shell: bash
+        run: |
+          conan profile detect --force
+          sed -i 's/compiler.cppstd=14/compiler.cppstd=17/' "$(conan profile path default)"
+
       - name: Setup Conan Cache
         uses: actions/cache@v4
         with:

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -23,7 +23,7 @@ jobs:
         os: [ ubuntu-latest ]
     runs-on: ${{ matrix.os }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       
       - name: Create Build Environment
         run: cmake -E make_directory ${{github.workspace}}/build
@@ -33,7 +33,7 @@ jobs:
         uses: turtlebrowser/get-conan@c171f295f3f507360ee018736a6608731aa2109d #v1.2
 
       - name: Setup Conan Cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ${{github.workspace}}/build/p/
           key: conan-${{ runner.os }}-${{ hashFiles('conanfile.py', '*/conanfile.py') }}
@@ -62,7 +62,7 @@ jobs:
       branch_name: ${{ steps.branch.outputs.name }}
     if: github.event_name != 'pull_request'
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
       
       - name: Remove suffix from Cmakelists.txt file
         run: |
@@ -91,7 +91,7 @@ jobs:
         run: echo "BRANCH_NAME=$(echo ${GITHUB_REF#refs/heads/} | tr / -)" >> $GITHUB_ENV
 
       - name: Persist to workspace
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: workspace
           path: ./
@@ -104,7 +104,7 @@ jobs:
     if: github.event_name != 'pull_request'
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
           
@@ -159,7 +159,7 @@ jobs:
     outputs:
       version_number: ${{ env.VERSION }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Create Build Environment
         run: cmake -E make_directory ${{github.workspace}}\build
@@ -175,7 +175,7 @@ jobs:
           sed -i 's/compiler.cppstd=14/compiler.cppstd=17/' "$(conan profile path default)"
 
       - name: Setup Conan Cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ${{github.workspace}}/build/p/
           key: conan-${{ runner.os }}-${{ hashFiles('conanfile.py', '*/conanfile.py') }}
@@ -215,7 +215,7 @@ jobs:
           Get-ChildItem -Force ${{github.workspace}}\build\bin
                          
       - name: Persist to workspace
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: windows-build
           path: |
@@ -229,10 +229,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:    
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Attach to workspace
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: windows-build
           
@@ -277,7 +277,7 @@ jobs:
     if: github.event_name != 'pull_request'
     steps:
       - name: Attach to workspace
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: workspace
 
@@ -285,7 +285,7 @@ jobs:
         run: cmake -E make_directory ${{github.workspace}}/build
 
       - name: Setup Conan Cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ${{github.workspace}}/build/p/
           key: conan-${{ runner.os }}-arm64-${{ hashFiles('conanfile.py', '*/conanfile.py') }}
@@ -343,17 +343,17 @@ jobs:
         run: echo ${{ env.REF_TAG }}
 
       - name: Login to Docker Hub
-        uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 #v3.3.0
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 #v4.1.0
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@49b3bc8e6bdd4a60e6116a5414239cba5943d3cf #v3.2.0
+        uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a #v4.0.0
 
       - name: Set up Docker Buildx
         id: buildx
-        uses: docker/setup-buildx-action@6524bf65af31da8d45b59e8c27de4bd072b392f5 #v3.8.0
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd #v4.0.0
 
       - name: Replace token
         run: |
@@ -369,7 +369,7 @@ jobs:
         id: docker_build
         env:
           IMAGE_NAME: netboxlabs/pktvisor
-        uses: docker/build-push-action@48aba3b46d1b1fec4febb7c5d0c644b249a11355 #v6.10.0
+        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f #v7.1.0
         with:
           builder: ${{ steps.buildx.outputs.name }}
           context: .
@@ -396,7 +396,7 @@ jobs:
     if: github.event_name != 'pull_request'
     steps:
       - name: Attach to workspace
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: workspace
 
@@ -404,7 +404,7 @@ jobs:
         run: cmake -E make_directory ${{github.workspace}}/build
 
       - name: Setup Conan Cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ${{github.workspace}}/build/p/
           key: conan-${{ runner.os }}-${{ hashFiles('conanfile.py', '*/conanfile.py') }}
@@ -460,17 +460,17 @@ jobs:
         run: echo ${{ env.REF_TAG }}
 
       - name: Login to Docker Hub
-        uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 #v3.3.0
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 #v4.1.0
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Set up Docker Buildx
         id: buildx
-        uses: docker/setup-buildx-action@6524bf65af31da8d45b59e8c27de4bd072b392f5 #v3.8.0
+        uses: docker/setup-buildx-action@4d04d5d9486b7bd6fa91e7baf45bbb4f8b9deedd #v4.0.0
         
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@49b3bc8e6bdd4a60e6116a5414239cba5943d3cf #v3.2.0
+        uses: docker/setup-qemu-action@ce360397dd3f832beb865e1373c09c0e9f86d70a #v4.0.0
         
       - name: Replace token
         run: |
@@ -485,7 +485,7 @@ jobs:
       - name: Build + push - pktvisor (multi-arch)
         env:
           IMAGE_NAME: netboxlabs/pktvisor
-        uses: docker/build-push-action@48aba3b46d1b1fec4febb7c5d0c644b249a11355 #v6.10.0
+        uses: docker/build-push-action@bcafcacb16a39f128d818304e6c9c0c18556b85f #v7.1.0
         with:
           builder: ${{ steps.buildx.outputs.name }}
           context: .

--- a/.github/workflows/build-release.yml
+++ b/.github/workflows/build-release.yml
@@ -168,6 +168,12 @@ jobs:
         id: conan
         uses: turtlebrowser/get-conan@c171f295f3f507360ee018736a6608731aa2109d #v1.2
 
+      - name: Setup Conan Profile
+        shell: bash
+        run: |
+          conan profile detect --force
+          sed -i 's/compiler.cppstd=14/compiler.cppstd=17/' "$(conan profile path default)"
+
       - name: Setup Conan Cache
         uses: actions/cache@v4
         with:

--- a/.github/workflows/build_cross.yml
+++ b/.github/workflows/build_cross.yml
@@ -43,7 +43,7 @@ jobs:
     steps:
       - name: Install sccache from cache
         id: cache-sccache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: bin/sccache
           key: sccache-v0.2.15
@@ -58,7 +58,7 @@ jobs:
 
       - name: Install compiler toolchain from cache
         id: cache-toolchain
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: toolchain
           key: toolchain-test-${{matrix.toolchain}}
@@ -73,7 +73,7 @@ jobs:
         run: pip install --no-cache-dir conan --force-reinstall
 
       - name: Restore sccache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.cache/sccache
           key: sccache-${{matrix.arch}}-${{github.head_ref||github.event.ref}}-${{github.run_id}}
@@ -82,7 +82,7 @@ jobs:
             sccache-${{matrix.arch}}-${{github.base_ref||github.event.repository.default_branch}}-
 
       - name: Checkout sources
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           path: src
 
@@ -116,7 +116,7 @@ jobs:
           EOF
 
       - name: Setup Conan Cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ${{github.workspace}}/src/build/p/
           key: conan-${{ runner.os }}-${{matrix.arch}}-${{ hashFiles('**/conanfile.py') }}
@@ -152,14 +152,14 @@ jobs:
           "${{github.workspace}}/bin/sccache" -s
 
       - name: Upload pktvisord
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: pktvisord-linux-${{matrix.arch}}-static
           path: ${{github.workspace}}/src/build/bin/pktvisord
           retention-days: 7
 
       - name: Upload pktvisor-reader
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: pktvisor-reader-linux-${{matrix.arch}}-static
           path: ${{github.workspace}}/src/build/bin/pktvisor-reader
@@ -177,7 +177,7 @@ jobs:
             arch: armv7lh
     steps:
       - name: Checkout sources
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Configure CMake to generate VERSION
         shell: bash
@@ -216,7 +216,7 @@ jobs:
           goarch: "arm64"
 
       - name: Upload pktvisor-cli
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: pktvisor-cli-${{matrix.os}}-${{matrix.arch}}
           path: pktvisor-cli

--- a/.github/workflows/build_debug.yml
+++ b/.github/workflows/build_debug.yml
@@ -15,7 +15,7 @@ jobs:
     outputs:
       version_number: ${{ steps.build.outputs.version }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Create Build Environment
         run: cmake -E make_directory ${{github.workspace}}/build
@@ -25,7 +25,7 @@ jobs:
         uses: turtlebrowser/get-conan@c171f295f3f507360ee018736a6608731aa2109d #v1.2
 
       - name: Setup Conan Cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ${{github.workspace}}/build/p/
           key: conan-${{ runner.os }}-amd64-${{ hashFiles('conanfile.py', '*/conanfile.py') }}
@@ -61,7 +61,7 @@ jobs:
         run: sudo cmake --build . --target coverage -- -j 4
 
       - name: Codecov
-        uses: codecov/codecov-action@v3
+        uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 #v6.0.0
         with:
           files: build/coverage.info
           name: pktvisor
@@ -70,13 +70,13 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - name: Create Build Environment
         run: cmake -E make_directory ${{github.workspace}}/build
 
       - name: Setup Conan Cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ${{github.workspace}}/build/p/
           key: conan-${{ runner.os }}-amd64-${{ hashFiles('conanfile.py', '*/conanfile.py') }}
@@ -104,7 +104,7 @@ jobs:
         run: ls -lha .
 
       - name: Upload artifacts
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: pktvisor-artifacts
           path: ./
@@ -115,7 +115,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Download to workspace
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: pktvisor-artifacts
 
@@ -158,7 +158,7 @@ jobs:
           sed -i -e "s/CP_URL/$ESCAPED_REPLACE/g" docker/run.sh
 
       - name: Login to Docker Hub
-        uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 #v3.3.0
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 #v4.1.0
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}

--- a/.github/workflows/code-ql.yml
+++ b/.github/workflows/code-ql.yml
@@ -24,7 +24,7 @@ jobs:
 
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     - name: Free disk space
       run: | 
@@ -38,7 +38,7 @@ jobs:
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v3
+      uses: github/codeql-action/init@5c8a8a642e79153f5d047b10ec1cba1d1cc65699 #v3.35.1
       with:
         languages: 'cpp'
         # If you wish to specify custom queries, you can do so here or in a config file.
@@ -77,14 +77,14 @@ jobs:
         rm -rf p/
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v3
+      uses: github/codeql-action/analyze@5c8a8a642e79153f5d047b10ec1cba1d1cc65699 #v3.35.1
       with:
         category: "/language:cpp"
         output: sarif-results
         upload: failure-only
 
     - name: filter-sarif
-      uses: advanced-security/filter-sarif@v1
+      uses: advanced-security/filter-sarif@2da736ff05ef065cb2894ac6892e47b5eac2c3c0 #v1.1
       with:
         patterns: |
           -pktvisor/build/p/**/*
@@ -92,12 +92,12 @@ jobs:
         output: sarif-results/cpp.sarif
 
     - name: Upload SARIF
-      uses: github/codeql-action/upload-sarif@v3
+      uses: github/codeql-action/upload-sarif@5c8a8a642e79153f5d047b10ec1cba1d1cc65699 #v3.35.1
       with:
         sarif_file: sarif-results/cpp.sarif
 
     - name: Upload loc as a Build Artifact
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         name: sarif-results
         path: sarif-results

--- a/.github/workflows/container-rescan.yaml
+++ b/.github/workflows/container-rescan.yaml
@@ -35,7 +35,7 @@ jobs:
           exit-code: "0"
 
       - name: Build rescan summary
-        uses: actions/github-script@ed597411d8f924073f98dfc5c65a23a2325f34cd # v8.0.0
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3 # v9.0.0
         with:
           script: |
             const fs = require('fs');
@@ -64,6 +64,6 @@ jobs:
 
       - name: Upload SARIF to GitHub Code Scanning
         if: "!cancelled()"
-        uses: github/codeql-action/upload-sarif@0d579ffd059c29b07949a3cce3983f0780820c98 # v4.32.6
+        uses: github/codeql-action/upload-sarif@c10b8064de6f491fea524254123dbe5e09572f13 #v4.35.1
         with:
           sarif_file: trivy-results.sarif

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,11 @@
 cmake_minimum_required(VERSION 3.24)
 
+# Must be set before project() so cmake/conan_provider.cmake (loaded via
+# CMAKE_PROJECT_TOP_LEVEL_INCLUDES) sees the correct standard and does not
+# fall back to MSVC's default of C++14 when generating the Conan profile.
+set(CMAKE_CXX_STANDARD 17)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
 #######################################################
 # VERSION
 #######################################################

--- a/conanfile.py
+++ b/conanfile.py
@@ -20,9 +20,9 @@ class Pktvisor(ConanFile):
             self.requires("libpcap/1.10.5", force=True)
         else:
             self.requires("npcap/1.70")
-        self.requires("opentelemetry-cpp/1.17.0")
+        self.requires("opentelemetry-cpp/1.24.0")
         self.requires("pcapplusplus/25.05")
-        self.requires("protobuf/5.27.0")
+        self.requires("protobuf/6.33.5")
         self.requires("sigslot/1.2.3")
         self.requires("fmt/10.2.1", force=True)
         self.requires("spdlog/1.15.0")
@@ -38,7 +38,7 @@ class Pktvisor(ConanFile):
 
     def build_requirements(self):
         self.tool_requires("corrade/2020.06")
-        self.tool_requires("protobuf/5.27.0")
+        self.tool_requires("protobuf/6.33.5")
 
     def layout(self):
         cmake_layout(self)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -45,7 +45,7 @@ target_link_libraries(visor-core
         datasketches
         rng
         timer
-        opentelemetry-cpp::opentelemetry_proto
+        opentelemetry-cpp::proto
         protobuf::libprotobuf
         maxminddb::maxminddb
         Corrade::Corrade

--- a/src/handlers/flow/test_flows.cpp
+++ b/src/handlers/flow/test_flows.cpp
@@ -408,6 +408,7 @@ TEST_CASE("Parse netflow v5 stream", "[netflow][flow]")
     FlowInputStream stream{"netflow-test"};
     stream.config_set("flow_type", "netflow");
     stream.config_set("pcap_file", "tests/fixtures/nf5.pcap");
+    visor::network::IpPort::set_csv_iana_ports("tests/fixtures/pktvisor-port-service-names.csv");
 
     visor::Config c;
     auto stream_proxy = stream.add_event_proxy(c);


### PR DESCRIPTION
## Summary

- **opentelemetry-cpp**: `1.17.0` → `1.24.0`
- **protobuf**: `5.27.0` → `6.33.5` (major version bump)
- **CMakeLists.txt**: move `CMAKE_CXX_STANDARD 17` before `project()` so `conan_provider.cmake` (which fires during `project()` via `CMAKE_PROJECT_TOP_LEVEL_INCLUDES`) sees the correct standard and does not fall back to MSVC's default C++14
- **Windows CI** (`build-develop.yml`, `build-release.yml`): add a _Setup Conan Profile_ step that pre-creates the default Conan profile with `cppstd=17` before CMake runs — fixes `--profile:build=default` picking up C++14 for `tool_requires` (protobuf build-time use)
- **GitHub Actions**: update all actions to latest versions across all 6 workflow files
- **test_flows.cpp**: fix flaky `Parse netflow v5 stream` test — was silently relying on global state populated by sflow tests; now calls `IpPort::set_csv_iana_ports()` directly so it is self-contained regardless of run order

## Test plan

- [x] Windows build passes with protobuf/6.33.5 and opentelemetry-cpp/1.24.0
- [x] Linux/macOS builds pass
- [x] `[netflow]` tagged tests pass when run in isolation (no sflow tests before them)
- [x] `--randomize-run-order` does not flip the netflow v5 port name assertion

🤖 Generated with [Claude Code](https://claude.com/claude-code)