### PR TITLE
test(netprobe): cover process_netprobe_icmp via handcrafted IcmpLayers

### DIFF
--- a/src/handlers/netprobe/test_net_probe.cpp
+++ b/src/handlers/netprobe/test_net_probe.cpp
@@ -1,5 +1,6 @@
 #include <catch2/catch_test_macros.hpp>
 #include <catch2/catch_test_visor.hpp>
+#include <catch2/otel_helpers.hpp>
 
 #include <sstream>
 
@@ -239,6 +240,35 @@ TEST_CASE("NetProbe to_prometheus emits configured metrics", "[netprobe][unit]")
     // Counter name is registered in Target ctor as "packets_timeout".
     CHECK(s.find("packets_timeout") != std::string::npos);
     CHECK(s.find("tprom") != std::string::npos);
+}
+
+TEST_CASE("NetProbe to_opentelemetry emits gauge values per target", "[netprobe][unit]")
+{
+    UnitFixture fx;
+
+    // tgt-ok: send (attempts++) then recv within ttl (successes++)
+    timespec ts_send{500, 0};
+    timespec ts_recv{500, 50'000'000};
+    fx.manager()->process_netprobe_tcp(true, "tgt-ok", ts_send);
+    fx.manager()->process_netprobe_tcp(false, "tgt-ok", ts_recv);
+
+    // tgt-fail: bare Timeout failure (no attempts increment per process_failure)
+    fx.manager()->process_failure(ErrorType::Timeout, "tgt-fail");
+    fx.manager()->process_failure(ErrorType::DnsLookupFailure, "tgt-fail");
+
+    opentelemetry::proto::metrics::v1::ScopeMetrics scope;
+    timespec start_ts{500, 0};
+    timespec end_ts{501, 0};
+    fx.manager()->bucket(0)->to_opentelemetry(scope, start_ts, end_ts, {});
+
+    using visor::test::otel_gauge_sum;
+    // Each Counter::to_opentelemetry emits a separate metric entry per target,
+    // so the bucket-level total for each name is the sum across all targets.
+    CHECK(otel_gauge_sum(scope, "netprobe_attempts") == 1);
+    CHECK(otel_gauge_sum(scope, "netprobe_successes") == 1);
+    CHECK(otel_gauge_sum(scope, "netprobe_packets_timeout") == 1);
+    CHECK(otel_gauge_sum(scope, "netprobe_dns_lookup_failures") == 1);
+    CHECK(otel_gauge_sum(scope, "netprobe_connect_failures") == 0);
 }
 
 TEST_CASE("NetProbe specialized_merge aggregates targets across buckets", "[netprobe][unit]")

--- a/src/handlers/netprobe/test_net_probe.cpp
+++ b/src/handlers/netprobe/test_net_probe.cpp
@@ -3,6 +3,17 @@
 
 #include <sstream>
 
+#ifdef __GNUC__
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wpedantic"
+#pragma GCC diagnostic ignored "-Wold-style-cast"
+#pragma GCC diagnostic ignored "-Wzero-as-null-pointer-constant"
+#endif
+#include <pcapplusplus/IcmpLayer.h>
+#ifdef __GNUC__
+#pragma GCC diagnostic pop
+#endif
+
 #include "NetProbeInputStream.h"
 #include "NetProbeStreamHandler.h"
 
@@ -131,6 +142,76 @@ TEST_CASE("NetProbe TCP transaction timeout", "[netprobe][unit]")
 
     CHECK(j["targets"]["tcp-late"]["attempts"] == 1);
     CHECK(j["targets"]["tcp-late"]["packets_timeout"] == 1);
+}
+
+TEST_CASE("NetProbe ICMP request/reply transaction lifecycle", "[netprobe][unit]")
+{
+    // Drive process_netprobe_icmp directly with handcrafted IcmpLayers
+    // (setEchoRequestData / setEchoReplyData), covering the ICMP_ECHO_REQUEST
+    // start-transaction path and the ICMP_ECHO_REPLY end-transaction path —
+    // both branches inside NetProbeMetricsManager::process_netprobe_icmp.
+    UnitFixture fx;
+
+    const uint8_t payload[] = {0xde, 0xad, 0xbe, 0xef};
+    timespec ts_req{200, 0};
+    timespec ts_rep{200, 12'000'000}; // 12ms later, well inside the default 5s TTL
+
+    pcpp::IcmpLayer req;
+    req.setEchoRequestData(/*id=*/0x1234, /*sequence=*/1, /*timestamp=*/0, payload, sizeof(payload));
+    fx.manager()->process_netprobe_icmp(&req, "icmp-tgt", ts_req);
+
+    pcpp::IcmpLayer reply;
+    reply.setEchoReplyData(/*id=*/0x1234, /*sequence=*/1, /*timestamp=*/0, payload, sizeof(payload));
+    fx.manager()->process_netprobe_icmp(&reply, "icmp-tgt", ts_rep);
+
+    json j;
+    fx.manager()->bucket(0)->to_json(j);
+    CHECK(j["targets"]["icmp-tgt"]["attempts"] == 1);
+    CHECK(j["targets"]["icmp-tgt"]["successes"] == 1);
+}
+
+TEST_CASE("NetProbe ICMP reply that times out records a failure", "[netprobe][unit]")
+{
+    // ECHO_REQUEST → start transaction; ECHO_REPLY 6s later (default TTL is
+    // 5s) → maybe_end_transaction returns TimedOut → process_failure(Timeout).
+    UnitFixture fx;
+
+    const uint8_t payload[] = {0x00, 0x11, 0x22, 0x33};
+    timespec ts_req{100, 0};
+    timespec ts_rep{106, 0};
+
+    pcpp::IcmpLayer req;
+    req.setEchoRequestData(0xCAFE, 7, 0, payload, sizeof(payload));
+    fx.manager()->process_netprobe_icmp(&req, "icmp-slow", ts_req);
+
+    pcpp::IcmpLayer reply;
+    reply.setEchoReplyData(0xCAFE, 7, 0, payload, sizeof(payload));
+    fx.manager()->process_netprobe_icmp(&reply, "icmp-slow", ts_rep);
+
+    json j;
+    fx.manager()->bucket(0)->to_json(j);
+    CHECK(j["targets"]["icmp-slow"]["attempts"] == 1);
+    CHECK(j["targets"]["icmp-slow"]["packets_timeout"] == 1);
+}
+
+TEST_CASE("NetProbe ICMP reply with no prior request is ignored", "[netprobe][unit]")
+{
+    // ECHO_REPLY with no matching start_transaction → Result::NotExist branch
+    // in maybe_end_transaction → neither new_transaction nor process_failure
+    // fires. Counters must stay at zero.
+    UnitFixture fx;
+
+    const uint8_t payload[] = {0xAA};
+    timespec ts{300, 0};
+
+    pcpp::IcmpLayer orphan_reply;
+    orphan_reply.setEchoReplyData(0xBEEF, 99, 0, payload, sizeof(payload));
+    fx.manager()->process_netprobe_icmp(&orphan_reply, "icmp-orphan", ts);
+
+    json j;
+    fx.manager()->bucket(0)->to_json(j);
+    // No targets created — the orphan reply produced no metrics.
+    CHECK(!j.contains("targets"));
 }
 
 TEST_CASE("NetProbe process_filtered increments event count", "[netprobe][unit]")


### PR DESCRIPTION
Picks up where #772 left off. \`NetProbeMetricsManager::process_netprobe_icmp\` was the largest remaining gap in \`NetProbeStreamHandler.cpp\` after that PR's NetProbe unit tests — it was previously only reached through the network-dependent (now \`SKIP\`'d) parent tests.

pcap++ exposes \`pcpp::IcmpLayer::setEchoRequestData\` / \`setEchoReplyData\` for building a fully-formed ICMP layer in memory, no parsed pcap needed.

## Three new TEST_CASEs

| Case | Flow | Asserts |
|---|---|---|
| request/reply transaction lifecycle | REQUEST id=0x1234 seq=1 → REPLY id=0x1234 seq=1 within TTL | attempts=1, successes=1 |
| reply that times out records a failure | REQUEST → REPLY 6s later (exceeds default 5s TTL) | attempts=1, packets_timeout=1 |
| reply with no prior request is ignored | bare REPLY only (no matching REQUEST) | no target row created |

Together these cover the ECHO_REQUEST branch, both ECHO_REPLY result paths (Valid + TimedOut), and the implicit NotExist no-op — the entire body of \`process_netprobe_icmp\`.

## Out of scope

The original ask also called out \`NetflowData.h\` / \`SflowData.h\` (NetFlow v1+v7 PCAPs, sFlow IPv6 samples). Those need new wire-format fixtures (either hand-written byte sequences or a scapy-style generator script). Tracking as a separate task — not bundled here to keep this reviewable.