### PR TITLE
ci: scope conan cache key by build type in build_debug.yml

### DIFF
--- a/.github/workflows/build_debug.yml
+++ b/.github/workflows/build_debug.yml
@@ -34,8 +34,8 @@ jobs:
         uses: actions/cache@v5
         with:
           path: ${{github.workspace}}/build/p/
-          key: conan-${{ runner.os }}-amd64-${{ hashFiles('conanfile.py', '*/conanfile.py') }}
-          restore-keys: conan-${{ runner.os }}-amd64-
+          key: conan-${{ runner.os }}-amd64-debug-${{ hashFiles('conanfile.py', '*/conanfile.py') }}
+          restore-keys: conan-${{ runner.os }}-amd64-debug-
 
       - name: linux package install
         run: |
@@ -95,8 +95,8 @@ jobs:
         uses: actions/cache@v5
         with:
           path: ${{github.workspace}}/build/p/
-          key: conan-${{ runner.os }}-amd64-${{ hashFiles('conanfile.py', '*/conanfile.py') }}
-          restore-keys: conan-${{ runner.os }}-amd64-
+          key: conan-${{ runner.os }}-amd64-debug-${{ hashFiles('conanfile.py', '*/conanfile.py') }}
+          restore-keys: conan-${{ runner.os }}-amd64-debug-
 
       - name: Build pktvisord + push symbol to backtrace.io
         uses: ./.github/actions/build-cpp


### PR DESCRIPTION
## Summary
- The Debug code-coverage and build jobs in `build_debug.yml` used the same conan cache key as the Release pipeline (`conan-${{ runner.os }}-amd64-<hash>`).
- `actions/cache@v5` saves only the first cache populated under a given key; the permissive `restore-keys: conan-${{ runner.os }}-amd64-` fallback then let Debug runs restore a Release-populated `build/p/` that lacks debug-built dependencies.
- Result: every Debug CI run rebuilt third-party deps from source instead of pulling them from cache.
- Fix: tag the Debug primary key and restore-keys with `-debug-` so the two pipelines maintain independent caches.

## Test plan
- [ ] First post-merge Debug run: expect a cache miss (new key), full conan build.
- [ ] Subsequent Debug runs: expect a cache hit and no source rebuild of conan packages.
- [ ] Release (`build-develop.yml`) cache behavior unchanged.