### PR TITLE
fix(ci): build pktvisor-cli with patched Go 1.26 on Alpine

### DIFF
--- a/.github/actions/build-go/Dockerfile
+++ b/.github/actions/build-go/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:bullseye
+FROM golang:1.26-alpine
 
 LABEL maintainer="netboxlabs"
 LABEL version="1.0.0"

--- a/.github/actions/build-go/entrypoint.sh
+++ b/.github/actions/build-go/entrypoint.sh
@@ -1,15 +1,17 @@
-#!/bin/bash
+#!/bin/sh
 #
-function build() {
+build() {
   echo "========================= Building pktvisor-cli ========================="
   cp -rf golang/ /src/
   # Copying this from previous build (cpp)
   cp -rf ./version.go /src/pkg/client/version.go
   cd /src
-  GOOS=$INPUT_GOOS GOARCH=$INPUT_GOARCH go build -o pktvisor-cli cmd/pktvisor-cli/main.go
+  # CGO_ENABLED=0 produces a portable static binary that runs on the glibc
+  # runtime image, even though it is built on an Alpine/musl toolchain.
+  CGO_ENABLED=0 GOOS=$INPUT_GOOS GOARCH=$INPUT_GOARCH go build -o pktvisor-cli cmd/pktvisor-cli/main.go
 }
 
-function copy() {
+copy() {
   echo "========================= Copying binary ========================="
   cp -rf /src/pktvisor-cli /github/workspace/
 }

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -30,11 +30,11 @@ RUN \
     PKG_CONFIG_PATH=/local/lib/pkgconfig cmake -DCMAKE_BUILD_TYPE=Release -DCMAKE_PROJECT_TOP_LEVEL_INCLUDES=./cmake/conan_provider.cmake .. && \
     make all -j 4
 
-FROM golang:latest AS gobuild
+FROM golang:1.26-alpine AS gobuild
 COPY golang/ /src/
 WORKDIR /src/
 COPY --from=cppbuild /pktvisor-src/golang/pkg/client/version.go /src/pkg/client/version.go
-RUN go build -o pktvisor-cli cmd/pktvisor-cli/main.go
+RUN CGO_ENABLED=0 go build -o pktvisor-cli cmd/pktvisor-cli/main.go
 
 FROM ubuntu:noble AS runtime
 


### PR DESCRIPTION
## Summary

Addresses the open [code-scanning alerts](https://github.com/netboxlabs/pktvisor/security/code-scanning) raised by the daily Trivy rescan of `netboxlabs/pktvisor:latest-develop`. All 47 alerts are stale toolchain/base-image CVEs, not source bugs.

The largest cluster — **33 Go `stdlib` CVEs (1 critical, 14 high, 16 medium, 2 low)** — exists because the published `pktvisor-cli` was built with **Go 1.24.6** via the floating `golang:bullseye` tag.

## Changes

- **`.github/actions/build-go/Dockerfile`**: `golang:bullseye` → `golang:1.26-alpine`. This action builds the CLI that ships in the published image. Go 1.26.3 fixes every flagged stdlib CVE.
- **`.github/actions/build-go/entrypoint.sh`**: switch to `#!/bin/sh` + POSIX function syntax (Alpine has no bash) and add `CGO_ENABLED=0` so the Alpine/musl toolchain still produces a portable **static** binary that runs on the glibc `ubuntu:noble` runtime.
- **`docker/Dockerfile`** (`gobuild` stage): `golang:latest` → `golang:1.26-alpine` with `CGO_ENABLED=0`, for consistency.

A minor-version pin (`1.26`) lets future patch releases flow in on each rebuild, mirroring how the runtime tracks `alpine:3.21`.

## On the remaining base-image CVEs

The 14 `libgnutls30t64` / `libgcrypt20` alerts need no code change — `Dockerfile.crashhandler` already runs `apt-get upgrade --yes`, so they clear once the image is rebuilt and republished by merging this PR (which triggers `build-develop`). The next daily `container-rescan` (or a manual dispatch) then closes all 47 alerts.

## Verification

Built locally on `golang:1.26-alpine`:
- `go version` → `go1.26.3`
- `CGO_ENABLED=0 go build` succeeds
- `ldd` → *"Not a valid dynamic program"* (fully static, glibc-compatible)