### PR TITLE
ci: add PR-triggered CodeQL for Go/Python (merge-gate prep)

### DIFF
--- a/.github/workflows/codeql-go-python.yml
+++ b/.github/workflows/codeql-go-python.yml
@@ -1,0 +1,42 @@
+name: "CodeQL (Go/Python)"
+
+# Lightweight CodeQL for Go and Python that runs on PRs, so it can back a
+# merge gate. The existing code-ql.yml continues to scan C/C++ nightly
+# (full gcc/g++ build, too heavy for every PR). See netboxlabs weekly
+# GitHub security hygiene enforcement push.
+
+on:
+  push:
+    branches: [develop]
+  pull_request:
+    branches: [develop]
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [go, python]
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@5c8a8a642e79153f5d047b10ec1cba1d1cc65699 # v3.35.1
+        with:
+          languages: ${{ matrix.language }}
+          queries: security-extended
+
+      - name: Autobuild
+        uses: github/codeql-action/autobuild@5c8a8a642e79153f5d047b10ec1cba1d1cc65699 # v3.35.1
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@5c8a8a642e79153f5d047b10ec1cba1d1cc65699 # v3.35.1
+        with:
+          category: "/language:${{ matrix.language }}"


### PR DESCRIPTION
Adds a lightweight CodeQL workflow for **Go and Python** that runs on `pull_request`, so SAST can be enforced as a merge gate on pktvisor. The existing `code-ql.yml` is unchanged and keeps scanning **C/C++ nightly** (full gcc/g++ build, too heavy to run on every PR).

Once this is producing per-PR results, I'll add the SAST Enforcement ruleset (CodeQL high+, default branch). C/C++ stays nightly-only for now.

From the weekly GitHub security hygiene review — you (Leo) approved option 2. cc @leoparente