### PR TITLE
Potential fix for code scanning alert no. 916: Binding a socket to all network interfaces

### DIFF
--- a/automated_tests/features/steps/utils.py
+++ b/automated_tests/features/steps/utils.py
@@ -136,7 +136,7 @@ def check_port_is_available(containers_id, available=True):
         retries = 0
         while available_port is None and retries < 10:
             s = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-            s.bind(('', 0))
+            s.bind(('127.0.0.1', 0))
             addr = s.getsockname()
             s.close()
             retries += 1


### PR DESCRIPTION
Potential fix for [https://github.com/netboxlabs/pktvisor/security/code-scanning/916](https://github.com/netboxlabs/pktvisor/security/code-scanning/916)

Use loopback-only binding instead of all-interface binding when selecting an ephemeral local port.

Best fix in this snippet: change `s.bind(('', 0))` to `s.bind(('127.0.0.1', 0))` in `automated_tests/features/steps/utils.py` inside `check_port_is_available`. This keeps existing functionality (get an available ephemeral port) while removing exposure on all interfaces. No additional imports, helper methods, or dependency changes are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
