### PR TITLE
chore(deps): upgrade conan dependencies

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -108,8 +108,12 @@ enable_testing()
 
 message(STATUS "Building pktvisor version ${CMAKE_PROJECT_VERSION_MAJOR}.${CMAKE_PROJECT_VERSION_MINOR}.${CMAKE_PROJECT_VERSION_PATCH}${VISOR_PRERELEASE}")
 
-# opentelemetry-cpp 1.26.0 generates proto headers with dllexport_decl but the Conan recipe doesn't propagate the macro to consumers; define it empty (static build).
-add_compile_definitions(OPENTELEMETRY_PROTO_API=)
+# opentelemetry-cpp 1.26.0 generates proto headers with dllexport_decl=OPENTELEMETRY_PROTO_API; the Conan recipe doesn't propagate the macro. On Windows the proto package is a DLL (consumers must import); elsewhere it expands to nothing.
+if(WIN32)
+    add_compile_definitions("OPENTELEMETRY_PROTO_API=__declspec(dllimport)")
+else()
+    add_compile_definitions(OPENTELEMETRY_PROTO_API=)
+endif()
 
 add_subdirectory(3rd)
 add_subdirectory(libs)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -107,6 +107,15 @@ set(VISOR_STATIC_PLUGINS)
 enable_testing()
 
 message(STATUS "Building pktvisor version ${CMAKE_PROJECT_VERSION_MAJOR}.${CMAKE_PROJECT_VERSION_MINOR}.${CMAKE_PROJECT_VERSION_PATCH}${VISOR_PRERELEASE}")
+
+# opentelemetry-cpp (>= 1.26.0) generates its protobuf headers with
+# protoc --cpp_out=dllexport_decl=OPENTELEMETRY_PROTO_API. For a static build the
+# macro must expand to nothing; upstream defines it on the proto target, but the
+# Conan recipe does not propagate that definition to consumers. The generated
+# *.pb.h are included from several targets (visor-core, handler tests, visor_test
+# helpers), so define it globally here for every consumer of those headers.
+add_compile_definitions(OPENTELEMETRY_PROTO_API=)
+
 add_subdirectory(3rd)
 add_subdirectory(libs)
 add_subdirectory(src)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -108,12 +108,7 @@ enable_testing()
 
 message(STATUS "Building pktvisor version ${CMAKE_PROJECT_VERSION_MAJOR}.${CMAKE_PROJECT_VERSION_MINOR}.${CMAKE_PROJECT_VERSION_PATCH}${VISOR_PRERELEASE}")
 
-# opentelemetry-cpp (>= 1.26.0) generates its protobuf headers with
-# protoc --cpp_out=dllexport_decl=OPENTELEMETRY_PROTO_API. For a static build the
-# macro must expand to nothing; upstream defines it on the proto target, but the
-# Conan recipe does not propagate that definition to consumers. The generated
-# *.pb.h are included from several targets (visor-core, handler tests, visor_test
-# helpers), so define it globally here for every consumer of those headers.
+# opentelemetry-cpp 1.26.0 generates proto headers with dllexport_decl but the Conan recipe doesn't propagate the macro to consumers; define it empty (static build).
 add_compile_definitions(OPENTELEMETRY_PROTO_API=)
 
 add_subdirectory(3rd)

--- a/conanfile.py
+++ b/conanfile.py
@@ -8,12 +8,12 @@ class Pktvisor(ConanFile):
 
     def requirements(self):
         self.requires("catch2/3.15.1")
-        self.requires("cpp-httplib/0.18.3")
+        self.requires("cpp-httplib/0.27.0")
         self.requires("docopt.cpp/0.6.3")
         self.requires("fast-cpp-csv-parser/cci.20240102")
         self.requires("json-schema-validator/2.4.0")
         self.requires("libmaxminddb/1.12.2")
-        self.requires("nlohmann_json/3.11.3")
+        self.requires("nlohmann_json/3.12.0", force=True)
         self.requires("openssl/3.6.3")
         if self.settings.os != "Windows":
             self.requires("libpcap/1.10.6", force=True)

--- a/conanfile.py
+++ b/conanfile.py
@@ -7,7 +7,7 @@ class Pktvisor(ConanFile):
     generators = "CMakeToolchain", "CMakeDeps"
 
     def requirements(self):
-        self.requires("catch2/3.14.0")
+        self.requires("catch2/3.15.1")
         self.requires("cpp-httplib/0.18.3")
         self.requires("docopt.cpp/0.6.3")
         self.requires("fast-cpp-csv-parser/cci.20240102")
@@ -16,19 +16,19 @@ class Pktvisor(ConanFile):
         self.requires("nlohmann_json/3.11.3")
         self.requires("openssl/3.6.2")
         if self.settings.os != "Windows":
-            self.requires("libpcap/1.10.5", force=True)
+            self.requires("libpcap/1.10.6", force=True)
         else:
-            self.requires("npcap/1.70")
-        self.requires("opentelemetry-cpp/1.24.0")
+            self.requires("npcap/1.86")
+        self.requires("opentelemetry-cpp/1.26.0")
         self.requires("pcapplusplus/25.05")
         self.requires("protobuf/6.33.5")
         self.requires("sigslot/1.2.3")
-        self.requires("fmt/10.2.1", force=True)
-        self.requires("spdlog/1.15.0")
+        #self.requires("fmt/10.2.1", force=True)
+        self.requires("spdlog/1.17.0")
         self.requires("uvw/3.4.0")
         self.requires("yaml-cpp/0.8.0")
         self.requires("robin-hood-hashing/3.11.5")
-        self.requires("libcurl/8.19.0")
+        self.requires("libcurl/8.20.0")
         if (
             "libc" not in self.settings.compiler.fields
             or self.settings.compiler.libc != "musl"

--- a/conanfile.py
+++ b/conanfile.py
@@ -14,7 +14,7 @@ class Pktvisor(ConanFile):
         self.requires("json-schema-validator/2.4.0")
         self.requires("libmaxminddb/1.12.2")
         self.requires("nlohmann_json/3.11.3")
-        self.requires("openssl/3.6.2")
+        self.requires("openssl/3.6.3")
         if self.settings.os != "Windows":
             self.requires("libpcap/1.10.6", force=True)
         else:
@@ -23,10 +23,9 @@ class Pktvisor(ConanFile):
         self.requires("pcapplusplus/25.05")
         self.requires("protobuf/6.33.5")
         self.requires("sigslot/1.2.3")
-        #self.requires("fmt/10.2.1", force=True)
         self.requires("spdlog/1.17.0")
         self.requires("uvw/3.4.0")
-        self.requires("yaml-cpp/0.8.0")
+        self.requires("yaml-cpp/0.9.0")
         self.requires("robin-hood-hashing/3.11.5")
         self.requires("libcurl/8.20.0")
         if (

--- a/conanfile.py
+++ b/conanfile.py
@@ -18,7 +18,7 @@ class Pktvisor(ConanFile):
         if self.settings.os != "Windows":
             self.requires("libpcap/1.10.6", force=True)
         else:
-            self.requires("npcap/1.86")
+            self.requires("npcap/1.86", force=True)
         self.requires("opentelemetry-cpp/1.26.0")
         self.requires("pcapplusplus/25.05")
         self.requires("protobuf/6.33.5")

--- a/src/GeoDB.cpp
+++ b/src/GeoDB.cpp
@@ -5,6 +5,7 @@
 #include "GeoDB.h"
 #include <cstring>
 #include <fmt/format.h>
+#include <fmt/ranges.h>
 #include <stdexcept>
 
 namespace visor::geo {

--- a/src/InputStream.h
+++ b/src/InputStream.h
@@ -7,6 +7,7 @@
 #include "AbstractModule.h"
 #include "InputEventProxy.h"
 #include "StreamHandler.h"
+#include <fmt/ranges.h>
 
 namespace visor {
 

--- a/src/StreamHandler.h
+++ b/src/StreamHandler.h
@@ -10,6 +10,7 @@
 #include "InputEventProxy.h"
 #include <ctime>
 #include <fmt/ostream.h>
+#include <fmt/ranges.h>
 #include <nlohmann/json.hpp>
 #include <sstream>
 

--- a/src/handlers/dns/v1/DnsStreamHandler.cpp
+++ b/src/handlers/dns/v1/DnsStreamHandler.cpp
@@ -5,6 +5,7 @@
 #include "DnsStreamHandler.h"
 #include "HandlerModulePlugin.h"
 #include "utils.h"
+#include <fmt/ranges.h>
 #ifdef __GNUC__
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wpedantic"

--- a/src/handlers/dns/v2/DnsStreamHandler.cpp
+++ b/src/handlers/dns/v2/DnsStreamHandler.cpp
@@ -5,6 +5,7 @@
 #include "DnsStreamHandler.h"
 #include "HandlerModulePlugin.h"
 #include "utils.h"
+#include <fmt/ranges.h>
 #ifdef __GNUC__
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wpedantic"

--- a/src/inputs/netprobe/NetProbeInputStream.cpp
+++ b/src/inputs/netprobe/NetProbeInputStream.cpp
@@ -7,6 +7,7 @@
 #include "PingProbe.h"
 #include "TcpProbe.h"
 #include "ThreadName.h"
+#include <fmt/ranges.h>
 #ifdef __GNUC__
 #pragma GCC diagnostic push
 #pragma GCC diagnostic ignored "-Wpedantic"


### PR DESCRIPTION
## What

Upgrade Conan dependencies to current versions and fix the build issues the upgrades surfaced.

### Upgraded
| Package | From | To |
|---|---|---|
| catch2 | 3.14.0 | 3.15.1 |
| libpcap | 1.10.5 | 1.10.6 |
| npcap (Windows) | 1.70 | 1.86 |
| opentelemetry-cpp | 1.24.0 | 1.26.0 |
| spdlog | 1.15.0 | 1.17.0 |
| libcurl | 8.19.0 | 8.20.0 |
| openssl | 3.6.2 | 3.6.3 |
| yaml-cpp | 0.8.0 | 0.9.0 |
| nlohmann_json | 3.11.3 | 3.12.0 |
| cpp-httplib | 0.18.3 | 0.27.0 |

Also drops the explicit `fmt/10.2.1` pin — `fmt` is now pulled transitively via `spdlog` (resolves to `fmt/12.x`).

### Intentionally held back (dependency-graph / platform constraints)
- **protobuf stays 6.33.5** — `opentelemetry-cpp/1.26.0` constrains `protobuf/[>=4.25.3 <7]`, so 7.x conflicts in the graph.
- **openssl stays on 3.x (3.6.3)** — a transitive dependency caps openssl at `<4`, so 4.0.1 conflicts.
- **cpp-httplib capped at 0.27.0** — from 0.28.0 the ConanCenter recipe unconditionally links `libanl` (non-blocking `getaddrinfo`) with no opt-out option; `libanl` does not exist on musl, which breaks the static musl cross-builds. 0.27.0 is the newest version that predates that recipe change.
- **nlohmann_json 3.12.0 uses `force=True`** — opentelemetry-cpp and json-schema-validator pin an exact `3.11.3`; the override is required to resolve the graph (header-only, API-compatible).

### Build fixes required by the upgrades
- **`OPENTELEMETRY_PROTO_API`** — opentelemetry-cpp 1.26.0 generates its protobuf headers with `--cpp_out=dllexport_decl=OPENTELEMETRY_PROTO_API`, but the Conan recipe does not propagate the macro to consumers. Defined in `CMakeLists.txt`: empty on macOS/Linux (static proto lib), `__declspec(dllimport)` on Windows (the Conan package builds proto as a DLL there).
- **`#include <fmt/ranges.h>`** — fmt 12 no longer exposes `fmt::join` transitively, so the files using it now include it explicitly.

## Testing
CI is green on all platforms: `unit-tests-mac`, `unit-tests-linux`, `build-win64`, both `pktvisor` musl cross-builds (x86_64 + aarch64), `code-coverage`, all `pktvisor-cli` variants, and CodeQL (Go + Python).

🤖 Generated with [Claude Code](https://claude.com/claude-code)