### PR TITLE
fix(pcap): don't widen explicit host_spec with the interface subnet (Refs #758)

### DIFF
--- a/cmd/pktvisor-reader/main.cpp
+++ b/cmd/pktvisor-reader/main.cpp
@@ -46,7 +46,9 @@ static const char USAGE[] =
       --geo-asn FILE        GeoLite2 ASN database to use for IP to ASN mapping (if enabled)
       -H HOSTSPEC           Specify subnets (comma separated) to consider HOST, in CIDR form. In live capture this /may/ be detected automatically
                             from capture device but /must/ be specified for pcaps. Example: "10.0.1.0/24,10.0.2.1/32,2001:db8::/64"
-                            Specifying this for live capture will append to any automatic detection.
+                            For live capture, specifying this defines the host set explicitly and
+                            disables automatic detection from the capture device; list every address
+                            family (IPv4 and IPv6) you need.
 )";
 
 namespace {

--- a/cmd/pktvisord/main.cpp
+++ b/cmd/pktvisord/main.cpp
@@ -111,7 +111,9 @@ static const char USAGE[] =
       -H HOSTSPEC                           Specify subnets (comma separated) to consider HOST, in CIDR form. In live capture this
                                             /may/ be detected automatically from capture device but /must/ be specified for pcaps.
                                             Example: "10.0.1.0/24,10.0.2.1/32,2001:db8::/64"
-                                            Specifying this for live capture will append to any automatic detection.
+                                            For live capture, specifying this defines the host set explicitly and
+                                            disables automatic detection from the capture device; list every address
+                                            family (IPv4 and IPv6) you need.
 )";
 
 namespace {

--- a/libs/visor_utils/test_utils.cpp
+++ b/libs/visor_utils/test_utils.cpp
@@ -103,3 +103,50 @@ TEST_CASE("parseHostSpec", "[utils]")
     }
 }
 
+// `str` is the canonical inet_ntop rendering of the binary address, not an echo of
+// any input string; the inputs below are already canonical so they round-trip. A
+// future non-canonical input (e.g. "2001:db8:0:0::1") would need its canonical form.
+// (std::pair brace-init resolves via utils.h, which gains #include <utility> in this task.)
+TEST_CASE("appendInterfaceHostSubnets", "[utils]")
+{
+    in_addr a4{};
+    REQUIRE(inet_pton(AF_INET, "192.168.50.23", &a4) == 1);
+    in6_addr a6{};
+    REQUIRE(inet_pton(AF_INET6, "2001:db8::1", &a6) == 1);
+
+    SECTION("skips interface hosts when a host set is already provided")
+    {
+        IPv4subnetList hostIPv4;
+        IPv6subnetList hostIPv6;
+        append_interface_host_subnets(true, {{a4, 24}}, {{a6, 64}}, hostIPv4, hostIPv6);
+        CHECK(hostIPv4.empty());
+        CHECK(hostIPv6.empty());
+    }
+
+    SECTION("appends interface hosts at their prefix when no host set provided")
+    {
+        IPv4subnetList hostIPv4;
+        IPv6subnetList hostIPv6;
+        append_interface_host_subnets(false, {{a4, 24}}, {{a6, 64}}, hostIPv4, hostIPv6);
+        REQUIRE(hostIPv4.size() == 1);
+        CHECK(hostIPv4[0].cidr == 24);
+        CHECK(hostIPv4[0].str == "192.168.50.23/24");
+        REQUIRE(hostIPv6.size() == 1);
+        CHECK(hostIPv6[0].cidr == 64);
+        CHECK(hostIPv6[0].str == "2001:db8::1/64");
+    }
+
+    SECTION("appends multiple addresses of the same family in order")
+    {
+        in_addr b4{};
+        REQUIRE(inet_pton(AF_INET, "10.0.0.1", &b4) == 1);
+        IPv4subnetList hostIPv4;
+        IPv6subnetList hostIPv6;
+        append_interface_host_subnets(false, {{a4, 24}, {b4, 32}}, {}, hostIPv4, hostIPv6);
+        REQUIRE(hostIPv4.size() == 2);
+        CHECK(hostIPv4[0].str == "192.168.50.23/24");
+        CHECK(hostIPv4[1].str == "10.0.0.1/32");
+        CHECK(hostIPv6.empty());
+    }
+}
+

--- a/libs/visor_utils/utils.cpp
+++ b/libs/visor_utils/utils.cpp
@@ -4,6 +4,12 @@
 #include <pcapplusplus/IpUtils.h>
 #include <fmt/format.h>
 #include <sstream>
+#include <utility> // std::pair
+#ifdef _WIN32
+#include <ws2tcpip.h>
+#else
+#include <arpa/inet.h>
+#endif
 
 namespace visor::lib::utils {
 
@@ -159,6 +165,30 @@ void parse_host_specs(const std::vector<std::string> &host_list, IPv4subnetList 
             }
             ipv4_list.push_back({ipv4, static_cast<uint8_t>(cidr_number), host});
         }
+    }
+}
+
+void append_interface_host_subnets(
+    bool host_set_provided,
+    const std::vector<std::pair<in_addr, uint8_t>> &v4_addrs,
+    const std::vector<std::pair<in6_addr, uint8_t>> &v6_addrs,
+    IPv4subnetList &host_ipv4,
+    IPv6subnetList &host_ipv6)
+{
+    // An explicit host_spec is authoritative: do not widen it with the capture
+    // interface's own address/subnet. (When no host_spec is given, the interface
+    // subnet is added on purpose, to distinguish inside vs. outside traffic.)
+    if (host_set_provided) {
+        return;
+    }
+    char buf[INET6_ADDRSTRLEN];
+    for (const auto &[addr, prefix] : v4_addrs) {
+        inet_ntop(AF_INET, &addr, buf, sizeof(buf));
+        host_ipv4.push_back({addr, prefix, std::string(buf) + "/" + std::to_string(prefix)});
+    }
+    for (const auto &[addr, prefix] : v6_addrs) {
+        inet_ntop(AF_INET6, &addr, buf, sizeof(buf));
+        host_ipv6.push_back({addr, prefix, std::string(buf) + "/" + std::to_string(prefix)});
     }
 }
 

--- a/libs/visor_utils/utils.cpp
+++ b/libs/visor_utils/utils.cpp
@@ -183,11 +183,15 @@ void append_interface_host_subnets(
     }
     char buf[INET6_ADDRSTRLEN];
     for (const auto &[addr, prefix] : v4_addrs) {
-        inet_ntop(AF_INET, &addr, buf, sizeof(buf));
+        if (inet_ntop(AF_INET, &addr, buf, sizeof(buf)) == nullptr) {
+            continue;
+        }
         host_ipv4.push_back({addr, prefix, std::string(buf) + "/" + std::to_string(prefix)});
     }
     for (const auto &[addr, prefix] : v6_addrs) {
-        inet_ntop(AF_INET6, &addr, buf, sizeof(buf));
+        if (inet_ntop(AF_INET6, &addr, buf, sizeof(buf)) == nullptr) {
+            continue;
+        }
         host_ipv6.push_back({addr, prefix, std::string(buf) + "/" + std::to_string(prefix)});
     }
 }

--- a/libs/visor_utils/utils.h
+++ b/libs/visor_utils/utils.h
@@ -23,6 +23,7 @@
 #include <optional>
 #include <stdexcept>
 #include <string>
+#include <utility>
 #include <vector>
 
 namespace visor::lib::utils {
@@ -60,6 +61,7 @@ bool ipv6_to_sockaddr(const pcpp::IPv6Address &ip, struct sockaddr_in6 *sa);
 
 std::vector<std::string> split_str_to_vec_str(const std::string &spec, const char &delimiter);
 void parse_host_specs(const std::vector<std::string> &host_list, IPv4subnetList &ipv4_list, IPv6subnetList &ipv6_list);
+void append_interface_host_subnets(bool host_set_provided, const std::vector<std::pair<in_addr, uint8_t>> &v4_addrs, const std::vector<std::pair<in6_addr, uint8_t>> &v6_addrs, IPv4subnetList &host_ipv4, IPv6subnetList &host_ipv6);
 std::optional<IPv4subnetList::const_iterator> match_subnet(IPv4subnetList &ipv4_list, uint32_t ipv4_val);
 std::optional<IPv6subnetList::const_iterator> match_subnet(IPv6subnetList &ipv6_list, const uint8_t *ipv6_val);
 bool match_subnet(IPv4subnetList &ipv4_list, IPv6subnetList &ipv6_list, const std::string &ip_val);

--- a/src/inputs/pcap/PcapInputStream.cpp
+++ b/src/inputs/pcap/PcapInputStream.cpp
@@ -30,6 +30,8 @@
 #include <cstdint>
 #include <pcapplusplus/IpUtils.h>
 #include <sstream>
+#include <utility>
+#include <vector>
 
 using namespace std::chrono;
 
@@ -582,24 +584,22 @@ void PcapInputStream::_get_hosts_from_libpcap_iface()
         return;
     }
     const std::string devName = _pcapDevice->getName();
+    std::vector<std::pair<in_addr, uint8_t>> v4_addrs;
+    std::vector<std::pair<in6_addr, uint8_t>> v6_addrs;
     for (ifaddrs *i = ifap; i != nullptr; i = i->ifa_next) {
         if (i->ifa_addr == nullptr || i->ifa_name == nullptr || devName != i->ifa_name) {
             continue;
         }
-        char buf[INET6_ADDRSTRLEN];
         if (i->ifa_addr->sa_family == AF_INET) {
             auto ip4 = reinterpret_cast<sockaddr_in *>(i->ifa_addr);
-            inet_ntop(AF_INET, &ip4->sin_addr, buf, sizeof(buf));
             uint8_t prefix = 32;
             if (i->ifa_netmask) {
                 auto nm = reinterpret_cast<sockaddr_in *>(i->ifa_netmask);
                 prefix = static_cast<uint8_t>(__builtin_popcount(ntohl(nm->sin_addr.s_addr)));
             }
-            std::string cidr = std::string(buf) + "/" + std::to_string(prefix);
-            _hostIPv4.push_back({ip4->sin_addr, prefix, cidr});
+            v4_addrs.emplace_back(ip4->sin_addr, prefix);
         } else if (i->ifa_addr->sa_family == AF_INET6) {
             auto ip6 = reinterpret_cast<sockaddr_in6 *>(i->ifa_addr);
-            inet_ntop(AF_INET6, &ip6->sin6_addr, buf, sizeof(buf));
             uint8_t prefix = 128;
             if (i->ifa_netmask) {
                 auto nm6 = reinterpret_cast<sockaddr_in6 *>(i->ifa_netmask);
@@ -608,11 +608,19 @@ void PcapInputStream::_get_hosts_from_libpcap_iface()
                     prefix += static_cast<uint8_t>(__builtin_popcount(nm6->sin6_addr.s6_addr[b]));
                 }
             }
-            std::string cidr = std::string(buf) + "/" + std::to_string(prefix);
-            _hostIPv6.push_back({ip6->sin6_addr, prefix, cidr});
+            v6_addrs.emplace_back(ip6->sin6_addr, prefix);
         }
     }
     freeifaddrs(ifap);
+
+    // An explicit host_spec is authoritative; only auto-add interface hosts when
+    // parse_host_spec() (run earlier in start()) did NOT already populate a host
+    // set. Do NOT gate on config_exists("host_spec"): the CLI default tap always
+    // sets host_spec (empty string when -H is omitted), so config_exists would be
+    // true for a plain `pktvisord <iface>` and wrongly skip auto-detection,
+    // leaving the host set empty and classifying every packet as unknown.
+    const bool host_set_provided = !_hostIPv4.empty() || !_hostIPv6.empty();
+    lib::utils::append_interface_host_subnets(host_set_provided, v4_addrs, v6_addrs, _hostIPv4, _hostIPv6);
 #endif
 }
 

--- a/src/inputs/pcap/PcapInputStream.cpp
+++ b/src/inputs/pcap/PcapInputStream.cpp
@@ -579,6 +579,15 @@ void PcapInputStream::_open_libpcap_iface(const std::string &bpfFilter)
 void PcapInputStream::_get_hosts_from_libpcap_iface()
 {
 #ifndef _WIN32
+    // An explicit host_spec is authoritative; skip interface auto-detection
+    // entirely (don't even call getifaddrs) when parse_host_spec() — run earlier
+    // in start() — already populated the host set. We gate on the parsed lists,
+    // NOT config_exists("host_spec"): the CLI default tap always sets host_spec
+    // (empty string when -H is omitted), so config_exists would be true for a
+    // plain `pktvisord <iface>` and wrongly skip auto-detection.
+    if (!_hostIPv4.empty() || !_hostIPv6.empty()) {
+        return;
+    }
     ifaddrs *ifap = nullptr;
     if (getifaddrs(&ifap) != 0 || ifap == nullptr) {
         return;
@@ -613,14 +622,10 @@ void PcapInputStream::_get_hosts_from_libpcap_iface()
     }
     freeifaddrs(ifap);
 
-    // An explicit host_spec is authoritative; only auto-add interface hosts when
-    // parse_host_spec() (run earlier in start()) did NOT already populate a host
-    // set. Do NOT gate on config_exists("host_spec"): the CLI default tap always
-    // sets host_spec (empty string when -H is omitted), so config_exists would be
-    // true for a plain `pktvisord <iface>` and wrongly skip auto-detection,
-    // leaving the host set empty and classifying every packet as unknown.
-    const bool host_set_provided = !_hostIPv4.empty() || !_hostIPv6.empty();
-    lib::utils::append_interface_host_subnets(host_set_provided, v4_addrs, v6_addrs, _hostIPv4, _hostIPv6);
+    // No explicit host_spec (guaranteed by the early return above): auto-add the
+    // interface's own addresses at their subnet prefix so direction classification
+    // works out of the box. The helper also self-guards on this flag.
+    lib::utils::append_interface_host_subnets(false, v4_addrs, v6_addrs, _hostIPv4, _hostIPv6);
 #endif
 }
 

--- a/src/inputs/pcap/PcapInputStream.cpp
+++ b/src/inputs/pcap/PcapInputStream.cpp
@@ -669,6 +669,14 @@ std::unique_ptr<InputEventProxy> PcapInputStream::create_event_proxy(const Confi
 
 void PcapInputStream::parse_host_spec()
 {
+    // Recompute the host set from scratch on every call. start() calls this each
+    // time, and stop() does not clear these lists, so without this a stopped/
+    // restarted stream would accumulate stale entries: a no-host_spec restart
+    // would keep the previous start's auto-detected interface subnets (and the
+    // _get_hosts_from_libpcap_iface() early return would then skip refreshing
+    // them via getifaddrs), and a host_spec restart would duplicate entries.
+    _hostIPv4.clear();
+    _hostIPv6.clear();
     if (config_exists("host_spec")) {
         lib::utils::parse_host_specs(lib::utils::split_str_to_vec_str(config_get<std::string>("host_spec"), ','),
             _hostIPv4, _hostIPv6);

--- a/src/inputs/pcap/PcapInputStream.cpp
+++ b/src/inputs/pcap/PcapInputStream.cpp
@@ -622,10 +622,13 @@ void PcapInputStream::_get_hosts_from_libpcap_iface()
     }
     freeifaddrs(ifap);
 
-    // No explicit host_spec (guaranteed by the early return above): auto-add the
-    // interface's own addresses at their subnet prefix so direction classification
-    // works out of the box. The helper also self-guards on this flag.
-    lib::utils::append_interface_host_subnets(false, v4_addrs, v6_addrs, _hostIPv4, _hostIPv6);
+    // The early return above already skipped getifaddrs when a host set was
+    // present, so this point is only reached with no explicit host_spec. Pass the
+    // computed flag (not a hard-coded false) so the helper enforces the same skip
+    // independently — defense-in-depth that keeps an explicit host_spec
+    // authoritative even if the early return is ever changed.
+    const bool host_set_provided = !_hostIPv4.empty() || !_hostIPv6.empty();
+    lib::utils::append_interface_host_subnets(host_set_provided, v4_addrs, v6_addrs, _hostIPv4, _hostIPv6);
 #endif
 }
 


### PR DESCRIPTION
Refs #758. (Does not auto-close — see discussion there.)

## Problem

On a **libpcap** live-capture input with an explicit `host_spec` (e.g. a VIP `/32`), pktvisord also appends the capture interface's address **at its netmask prefix** (e.g. `192.168.50.23/24`) to the "host" set used for direction classification. The user's `host_spec` is silently widened to the whole subnet.

The result is DNS direction misclassification. With `host_spec: 192.168.50.2/32`, the query `client → VIP` classifies correctly (`dst=VIP` wins on the `/32` → `toHost`), but the **response** `VIP → client` has `dst=client`, which matches the interface `/24` → `toHost` instead of `fromHost`. Depending on the handler this either breaks transaction pairing (v2: query in the `in` map, response looked up in the `out` map → never pairs → `dns_xact_in` stays 0) or mis-increments (v1: pairs, but counts `xacts_out` instead of `xacts_in`). Either way server-side DNS is reported as client-side, the symptom in #758.

The **af_packet** source never does interface host-detection (hence `pcap_source: af_packet` is the known workaround), and **pcap_file** never auto-detects — so the defect is specific to live libpcap capture.

## Fix

When `parse_host_spec()` has produced a **non-empty** host set, the explicit `host_spec` is authoritative and interface auto-detection is skipped (libpcap now matches af_packet). When no usable `host_spec` is given, the prior behavior is preserved exactly: the interface address is auto-added at its on-link/subnet prefix (the intentional inside/outside distinction).

The gate is **`!_hostIPv4.empty() || !_hostIPv6.empty()`** — the lists `parse_host_spec()` filled — and deliberately **not** `config_exists("host_spec")`: the CLI's default tap always emits `host_spec` (the empty string when `-H` is omitted), so `config_exists` would wrongly skip auto-detection for a plain `pktvisord <iface>` and classify every packet as `unknown`.

The decision + entry construction were extracted into a pure, unit-testable helper `lib::utils::append_interface_host_subnets(...)`, so the new logic is covered without binding a live NIC. `PcapInputStream::_get_hosts_from_libpcap_iface()` keeps the OS `getifaddrs` gather and delegates to it.

- `libs/visor_utils/{utils.h,utils.cpp,test_utils.cpp}` — the helper + a unit test covering both gate branches and multi-address ordering.
- `src/inputs/pcap/PcapInputStream.cpp` — rewire the libpcap host detection through the helper.
- `cmd/pktvisord/main.cpp`, `cmd/pktvisor-reader/main.cpp` — `-H` help text now documents that, for live capture, it **defines the host set explicitly and disables automatic detection** (was "append to any automatic detection").

## Behavior / compatibility

- **No change** for inputs that don't set a usable `host_spec` — including a plain `pktvisord <iface>` (empty `host_spec` → auto-detect, unchanged).
- Inputs with a non-empty `host_spec` on a libpcap interface now get exactly the host set they configured; this shifts all direction-derived metrics for them (`net` in/out, flow, `dns_xact_in/out`) — they were previously misclassified.
- **`-H` semantics change (intentional, per #758):** a non-empty `-H` is now authoritative (replace), not append. Help text updated in both binaries.
- A `host_spec` in **either** family disables interface auto-detection for **both** families; on a dual-stack interface list every family you care about (the other family's traffic would otherwise be direction `unknown`, and is dropped if the v2 DNS handler's `only_xact_directions` filter excludes `unknown`).

## Testing

- New `unit-tests-visor-utils` case `appendInterfaceHostSubnets` (skip-when-provided / append-when-not / multiple same-family addresses): pass (19 assertions; full util suite 45).
- `unit-tests-input-pcap`: pass, no regression.
- The live `getifaddrs` path is not CI-reachable (no real NIC in CI); the pure helper carries the automated coverage. Manually verifiable on a live host: `host_spec: <VIP>/32` → `dns_xact_in_total` increments for server-side DNS; no `-H` → auto-detect unchanged.

## Reviews

Built spec → plan → 5 rounds of adversarial review (which caught a critical gate bug: an earlier draft gated on `config_exists("host_spec")`, which would have broken the dominant `pktvisord <iface>` path) → subagent-driven implementation with per-task + whole-branch review → a final adversarial review over the commits (build + tests run). All clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
